### PR TITLE
add context pacakge with WithResetableTimeout() functionality.

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,0 +1,65 @@
+package context
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+type resetableTimeoutContext struct {
+	mutex   sync.RWMutex
+	parent  context.Context
+	current context.Context
+	cancel  context.CancelFunc
+}
+
+// WithResetableTimeout acts like context.WithTimeout, but enables the ResetTimeout() function on the returned context
+func WithResetableTimeout(ctx context.Context, dur time.Duration) (context.Context, context.CancelFunc) {
+	res := &resetableTimeoutContext{
+		parent: ctx,
+	}
+	res.current, res.cancel = context.WithTimeout(ctx, dur)
+	return res, func() {
+		res.mutex.RLock()
+		defer res.mutex.RUnlock()
+		res.cancel()
+	}
+}
+
+// ResetTimeout resets the timeout of the given context if it was created using WithResetableTimeout
+// With this function you can extend the timeout of a context
+func ResetTimeout(ctx context.Context, dur time.Duration) error {
+	resetable, ok := ctx.(*resetableTimeoutContext)
+	if !ok {
+		return errors.New("context timeout is not resetable")
+	}
+	resetable.mutex.Lock()
+	defer resetable.mutex.Unlock()
+	resetable.current, resetable.cancel = context.WithTimeout(resetable.parent, dur)
+	return nil
+}
+
+func (ctx *resetableTimeoutContext) Deadline() (deadline time.Time, ok bool) {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	return ctx.current.Deadline()
+}
+
+func (ctx *resetableTimeoutContext) Done() <-chan struct{} {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	return ctx.current.Done()
+}
+
+func (ctx *resetableTimeoutContext) Err() error {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	return ctx.current.Err()
+}
+
+func (ctx *resetableTimeoutContext) Value(key interface{}) interface{} {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	return ctx.current.Value(key)
+}

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -1,0 +1,33 @@
+package context
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResetableTimeoutContextBasicBehavior(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := WithResetableTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	time.Sleep(50 * time.Millisecond)
+	assert.Nil(t, ctx.Err())
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, context.DeadlineExceeded, ctx.Err())
+}
+
+func TestResetableTimeoutContextReseting(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := WithResetableTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	time.Sleep(50 * time.Millisecond)
+	assert.Nil(t, ctx.Err())
+	err := ResetTimeout(ctx, 100*time.Millisecond)
+	assert.Nil(t, err)
+	time.Sleep(60 * time.Millisecond)
+	assert.Nil(t, ctx.Err())
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, context.DeadlineExceeded, ctx.Err())
+}


### PR DESCRIPTION
**What**

This commit adds a `context` package which contains an implementation
of a resetable-timeout context. This can be useful if you want to
extend the timeout of a given context which would be not trivially
possible otherwise.

**Why**

I implemented this in the log-streaming server to decide if I should continue or stop the stream delivery after not seeing any new messages in a certain period of time. This implementation makes the code much easier.

To get an idea, look at this example:

```go
ctx, cancel := context.WithResetableTimeout(parent, 100*time.Millisecond)
defer cancel()
doWork() // for approx 80ms and decide then to take another 100ms to complete it
context.ResetTimeout(ctx, 100 * time.Millisecond)
doMoreWork() // which will not timeout in 20ms but in 100ms!
```