### PR TITLE
SQL identifier max lenght is 63

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,6 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lib/pq v1.1.1
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
@@ -31,8 +29,9 @@ require (
 	github.com/uber/jaeger-client-go v2.16.0+incompatible
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect
 	github.com/urfave/negroni v1.0.0
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 // indirect
 	google.golang.org/grpc v1.22.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
+
+go 1.13

--- a/pkg/validation/rules.go
+++ b/pkg/validation/rules.go
@@ -23,7 +23,7 @@ const (
 	MaxNameLength = 255
 	// MaxSQLIdentifierLength is the max length of a sql name
 	// that we can support
-	MaxSQLIdentifierLength = 64
+	MaxSQLIdentifierLength = 63
 	sqlIdentifierErrorMsg  = "SQL names must start with an alphabetic character and may only include alphanumeric characters and underscores '_'"
 )
 

--- a/pkg/validation/rules_test.go
+++ b/pkg/validation/rules_test.go
@@ -32,6 +32,10 @@ func TestSQLIdentifier(t *testing.T) {
 	t.Run("Returns no error if the value is valid", func(t *testing.T) {
 		require.NoError(t, SQLIdentifier("name"))
 	})
+	t.Run("Returns error for names over 63 characters", func(t *testing.T) {
+		tooLong := "a123456789_123456789_123456789_123456789_123456789_123456789_123"
+		require.Error(t, SQLIdentifier(tooLong), len(tooLong))
+	})
 	t.Run("Returns error if the value is invalid", func(t *testing.T) {
 		err := SQLIdentifier("n@me")
 		require.Error(t, err)


### PR DESCRIPTION
**What**
- We should actually enforce that names are shorter than 64 characters,
  postgres will otherwise truncate the last character.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>