### PR TITLE
Add chi router generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 // indirect
 	google.golang.org/grpc v1.22.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v2 v2.2.1
 )
 
 go 1.13

--- a/pkg/generators/router/router.go
+++ b/pkg/generators/router/router.go
@@ -1,0 +1,265 @@
+package router
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"text/template"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+// DefaultPackageName used in the router's source code
+const DefaultPackageName = "openapi"
+
+// Options represent all the possible options of the generator
+type Options struct {
+	// PackageName of the generated router source code (`DefaultPackageName` by default)
+	PackageName string
+
+	// FailNoGroup if true the generator returns an error if an endpoint without
+	// `x-handler-group` attribute was found. Otherwise, this endpoint will be skipped silently.
+	FailNoGroup bool
+
+	// FailNoOperationID if true the generator returns an error if an endpoint without
+	// `operationId` attribute was found. Otherwise, this endpoint will be skipped silently.
+	FailNoOperationID bool
+}
+
+// Generate writes a chi router source code into `router` reading the YAML definition of the
+// Open API 3.0 spec from the `specFile`. It supports options `opts` (see `Options`).
+//
+// All included into generation endpoints must have `operationId` and `x-handler-group`
+// attributes. Depending on the `opts` generator will either produce an error or skip
+// endpoints without these attributes.
+func Generate(specFile io.Reader, router io.Writer, opts Options) (err error) {
+	decoder := yaml.NewDecoder(specFile)
+	spec := spec{}
+	err = decoder.Decode(&spec)
+	if err != nil {
+		return err
+	}
+
+	if opts.PackageName == "" {
+		opts.PackageName = DefaultPackageName
+	}
+
+	tctx, err := createTemplateCtx(spec, opts)
+	if err != nil {
+		return err
+	}
+
+	return routerTemplate.Execute(router, tctx)
+}
+
+type templateCtx struct {
+	PackageName   string
+	Spec          spec
+	Groups        map[string]*handlerGroup
+	PathsByGroups map[string]*pathsInGroup
+}
+
+type pathsInGroup struct {
+	AllowedMethodsByPaths map[string]*methodsInPath
+}
+
+type methodsInPath struct {
+	OperationsByMethods map[string]string
+}
+
+type handlerGroup struct {
+	Endpoints []endpoint
+}
+
+type endpoint struct {
+	Summary     string `yaml:"summary"`
+	Description string `yaml:"description"`
+	OperationID string `yaml:"operationId"`
+	Group       string `yaml:"x-handler-group"`
+}
+
+type path struct {
+	GET    *endpoint `yaml:"get"`
+	POST   *endpoint `yaml:"post"`
+	PUT    *endpoint `yaml:"put"`
+	PATCH  *endpoint `yaml:"patch"`
+	DELETE *endpoint `yaml:"delete"`
+}
+
+type info struct {
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+	Version     string `yaml:"version"`
+}
+
+type spec struct {
+	Info  info            `yaml:"info"`
+	Paths map[string]path `yaml:"paths"`
+}
+
+func createTemplateCtx(spec spec, opts Options) (out templateCtx, err error) {
+	out.PackageName = opts.PackageName
+	out.Spec = spec
+	out.Groups = make(map[string]*handlerGroup)
+	out.PathsByGroups = make(map[string]*pathsInGroup)
+
+	for path, definition := range spec.Paths {
+		err = setEndpoint(&out, opts, http.MethodGet, path, definition.GET)
+		if err != nil {
+			return out, err
+		}
+
+		err = setEndpoint(&out, opts, http.MethodPost, path, definition.POST)
+		if err != nil {
+			return out, err
+		}
+
+		err = setEndpoint(&out, opts, http.MethodPut, path, definition.PUT)
+		if err != nil {
+			return out, err
+		}
+
+		err = setEndpoint(&out, opts, http.MethodPatch, path, definition.PATCH)
+		if err != nil {
+			return out, err
+		}
+
+		err = setEndpoint(&out, opts, http.MethodDelete, path, definition.DELETE)
+		if err != nil {
+			return out, err
+		}
+	}
+	return out, nil
+}
+
+func setEndpoint(out *templateCtx, opts Options, method, path string, e *endpoint) error {
+	if e == nil {
+		return nil
+	}
+	if e.Group == "" {
+		if opts.FailNoGroup {
+			return fmt.Errorf("`%s %s` does not have the `x-handler-group` value", method, path)
+		}
+		return nil
+	}
+	if e.OperationID == "" {
+		if opts.FailNoOperationID {
+			return fmt.Errorf("`%s %s` does not have the `operationId` value", method, path)
+		}
+		return nil
+	}
+
+	group := out.Groups[e.Group]
+	if group == nil {
+		group = &handlerGroup{}
+		out.Groups[e.Group] = group
+	}
+	group.Endpoints = append(group.Endpoints, *e)
+
+	exPathsInGroup := out.PathsByGroups[e.Group]
+	if exPathsInGroup == nil {
+		exPathsInGroup = &pathsInGroup{
+			AllowedMethodsByPaths: make(map[string]*methodsInPath),
+		}
+		out.PathsByGroups[e.Group] = exPathsInGroup
+	}
+
+	exMethodsInPath := exPathsInGroup.AllowedMethodsByPaths[path]
+	if exMethodsInPath == nil {
+		exMethodsInPath = &methodsInPath{
+			OperationsByMethods: make(map[string]string, 5), // we have only 5 HTTP methods
+		}
+		exPathsInGroup.AllowedMethodsByPaths[path] = exMethodsInPath
+	}
+
+	exMethodsInPath.OperationsByMethods[method] = e.OperationID
+
+	return nil
+}
+
+func httpMethod(str string) string {
+	return firstUpper(strings.ToLower(str))
+}
+func firstLower(str string) string {
+	return strings.ToLower(str[0:1]) + str[1:]
+}
+func firstUpper(str string) string {
+	return strings.ToUpper(str[0:1]) + str[1:]
+}
+func commentBlock(str string) string {
+	return "// " + strings.Replace(strings.TrimSpace(str), "\n", "\n// ", -1)
+}
+
+// template definitions
+var (
+	fmap = template.FuncMap{
+		"firstLower":   firstLower,
+		"firstUpper":   firstUpper,
+		"httpMethod":   httpMethod,
+		"commentBlock": commentBlock,
+	}
+	routerTemplateSource = `package {{ .PackageName }}
+
+// This file is auto-generated, don't modify it manually
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi"
+)
+
+{{range $name, $group := .Groups }}
+// {{ $name }}Handler handles the operations of the '{{ $name }}' handler group.
+type {{ $name }}Handler interface {
+{{- range $idx, $e := $group.Endpoints }}
+	{{ (printf "%s %s" $e.OperationID $e.Description) | commentBlock }}
+	{{ $e.OperationID }}(w http.ResponseWriter, r *http.Request)
+{{- end}}
+}
+{{end}}
+// NewRouter creates a new router for the spec and the given handlers.
+// {{ .Spec.Info.Title }}
+//
+{{ .Spec.Info.Description | commentBlock }}
+//
+// {{ .Spec.Info.Version }}
+//
+func NewRouter(
+{{- range $group, $def := .PathsByGroups }}
+	{{ $group | firstLower}}Handler {{ $group | firstUpper }}Handler,
+{{- end}}
+) http.Handler {
+
+	r := chi.NewRouter()
+{{range $group, $pathsInGroup := .PathsByGroups }}
+// '{{ $group }}' group
+{{ range $path, $methodsInPath := $pathsInGroup.AllowedMethodsByPaths }}
+// '{{ $path }}'
+r.Options("{{ $path }}", optionsHandlerFunc(
+{{- range $method, $operation := $methodsInPath.OperationsByMethods }}
+	http.Method{{ $method | httpMethod }},
+{{- end}}
+))
+
+{{- range $method, $operation := $methodsInPath.OperationsByMethods }}
+r.{{ $method | httpMethod }}("{{ $path }}", {{ $group | firstLower }}Handler.{{ $operation }})
+{{- end}}
+{{end}}
+{{- end}}
+	return r
+}
+
+func optionsHandlerFunc(allowedMethods ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Allow", strings.Join(allowedMethods, ", "))
+	}
+}
+`
+	routerTemplate = template.Must(
+		template.New("router").
+			Funcs(fmap).
+			Parse(routerTemplateSource),
+	)
+)

--- a/pkg/generators/router/router_test.go
+++ b/pkg/generators/router/router_test.go
@@ -1,0 +1,202 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHttpMethod(t *testing.T) {
+	require.Equal(t, "Get", httpMethod("GET"))
+	require.Equal(t, "Get", httpMethod("get"))
+	require.Equal(t, "Get", httpMethod("gEt"))
+}
+
+func TestFirstLower(t *testing.T) {
+	require.Equal(t, "string", firstLower("string"))
+	require.Equal(t, "sTRING", firstLower("STRING"))
+	require.Equal(t, "string", firstLower("String"))
+}
+
+func TestFirstUpper(t *testing.T) {
+	require.Equal(t, "String", firstUpper("string"))
+	require.Equal(t, "STRING", firstUpper("STRING"))
+	require.Equal(t, "String", firstUpper("String"))
+}
+
+func TestCommentBlock(t *testing.T) {
+	require.Equal(t, "// some\n// multiline\n// comment", commentBlock("some\nmultiline\ncomment\n"))
+	require.Equal(t, "// single line comment", commentBlock("single line comment"))
+}
+
+func TestSetEndpoint(t *testing.T) {
+	valid := endpoint{
+		OperationID: "TestOperation",
+		Group:       "TestGroup",
+	}
+
+	path := "/some/path"
+	method := http.MethodGet
+	cases := []struct {
+		name   string
+		e      *endpoint
+		opts   Options
+		exp    templateCtx
+		expErr string
+	}{
+		{
+			name: "returns populated dictionaries for a valid endpoint",
+			e:    &valid,
+			exp: templateCtx{
+				Groups: map[string]*handlerGroup{
+					valid.Group: &handlerGroup{Endpoints: []endpoint{valid}},
+				},
+				PathsByGroups: map[string]*pathsInGroup{
+					valid.Group: &pathsInGroup{
+						AllowedMethodsByPaths: map[string]*methodsInPath{
+							path: &methodsInPath{
+								OperationsByMethods: map[string]string{
+									method: valid.OperationID,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "does not populate if the endpoint is nil",
+			exp: templateCtx{
+				Groups:        make(map[string]*handlerGroup),
+				PathsByGroups: make(map[string]*pathsInGroup),
+			},
+		},
+		{
+			name: "does not populate if the endpoint has no group",
+			e:    &endpoint{OperationID: "some"},
+			exp: templateCtx{
+				Groups:        make(map[string]*handlerGroup),
+				PathsByGroups: make(map[string]*pathsInGroup),
+			},
+		},
+		{
+			name: "does not populate if the endpoint has no operation ID",
+			e:    &endpoint{Group: "some"},
+			exp: templateCtx{
+				Groups:        make(map[string]*handlerGroup),
+				PathsByGroups: make(map[string]*pathsInGroup),
+			},
+		},
+		{
+			name:   "returns error if opts.FailNoGroup = true and the endpoint has no group",
+			e:      &endpoint{OperationID: "some"},
+			opts:   Options{FailNoGroup: true},
+			expErr: fmt.Sprintf("`%s %s` does not have the `x-handler-group` value", method, path),
+		},
+		{
+			name:   "returns error if opts.FailNoOperationID = true and the endpoint has no operation ID",
+			e:      &endpoint{Group: "some"},
+			opts:   Options{FailNoOperationID: true},
+			expErr: fmt.Sprintf("`%s %s` does not have the `operationId` value", method, path),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &templateCtx{
+				Groups:        make(map[string]*handlerGroup),
+				PathsByGroups: make(map[string]*pathsInGroup),
+			}
+
+			err := setEndpoint(out, tc.opts, method, path, tc.e)
+			if tc.expErr != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.expErr, err.Error())
+				return
+			}
+
+			require.EqualValues(t, tc.exp, *out)
+		})
+	}
+}
+
+func TestCreateTemplateCtx(t *testing.T) {
+	spec := spec{
+		Info: info{
+			Title:       "Title",
+			Description: "Description",
+			Version:     "Version",
+		},
+		Paths: map[string]path{
+			"/some/path": path{
+				GET: &endpoint{
+					Summary:     "GET Summary",
+					Description: "GET Description",
+					OperationID: "GETOperationID",
+					Group:       "Group",
+				},
+				POST: &endpoint{
+					Summary:     "POST Summary",
+					Description: "POST Description",
+					OperationID: "POSTOperationID",
+					Group:       "Group",
+				},
+				PUT: &endpoint{
+					Summary:     "PUT Summary",
+					Description: "PUT Description",
+					OperationID: "PUTOperationID",
+					Group:       "Group",
+				},
+				PATCH: &endpoint{
+					Summary:     "PATCH Summary",
+					Description: "PATCH Description",
+					OperationID: "PATCHOperationID",
+					Group:       "Group",
+				},
+				DELETE: &endpoint{
+					Summary:     "DELETE Summary",
+					Description: "DELETE Description",
+					OperationID: "DELETEOperationID",
+					Group:       "Group",
+				},
+			},
+			"/another/path": path{},
+		},
+	}
+
+	out, err := createTemplateCtx(spec, Options{PackageName: "Test"})
+	require.NoError(t, err)
+	expected := templateCtx{
+		PackageName: "Test",
+		Spec:        spec,
+		Groups: map[string]*handlerGroup{
+			"Group": &handlerGroup{
+				Endpoints: []endpoint{
+					*spec.Paths["/some/path"].GET,
+					*spec.Paths["/some/path"].POST,
+					*spec.Paths["/some/path"].PUT,
+					*spec.Paths["/some/path"].PATCH,
+					*spec.Paths["/some/path"].DELETE,
+				},
+			},
+		},
+		PathsByGroups: map[string]*pathsInGroup{
+			"Group": &pathsInGroup{
+				AllowedMethodsByPaths: map[string]*methodsInPath{
+					"/some/path": &methodsInPath{
+						OperationsByMethods: map[string]string{
+							"GET":    "GETOperationID",
+							"POST":   "POSTOperationID",
+							"PUT":    "PUTOperationID",
+							"PATCH":  "PATCHOperationID",
+							"DELETE": "DELETEOperationID",
+						},
+					},
+				},
+			},
+		},
+	}
+	require.EqualValues(t, expected, out)
+}


### PR DESCRIPTION
**What**

Generate writes a `chi` router source code into a given `Writer` reading
the YAML definition of the Open API 3.0 spec from a given `Reader`.
It supports options to set a package name and error behavior.

All included into generation endpoints must have `operationId` and `x-handler-group`
attributes. Depending on the options the generator will either produce an error or skip
endpoints without these attributes.