### PR TITLE
Allow scanning string and nil values from the db

### DIFF
--- a/pkg/db/serialization/json_blob.go
+++ b/pkg/db/serialization/json_blob.go
@@ -3,7 +3,7 @@ package serialization
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"errors"
+	"fmt"
 )
 
 // JSONBlob returns an Serializable using json to []byte serialization
@@ -21,11 +21,17 @@ func (b jsonBlob) GetData() interface{} {
 }
 
 func (b jsonBlob) Scan(src interface{}) error {
-	bs, ok := src.([]byte)
-	if !ok {
-		return errors.New("source must be a byte slice")
+	switch value := src.(type) {
+	case nil:
+		b.data = nil
+		return nil
+	case []byte:
+		return json.Unmarshal(value, b.data)
+	case string:
+		return json.Unmarshal([]byte(value), b.data)
+	default:
+		return fmt.Errorf("unknown json object type %T", src)
 	}
-	return json.Unmarshal(bs, b.data)
 }
 
 func (b jsonBlob) Value() (driver.Value, error) {

--- a/pkg/db/serialization/json_blob_test.go
+++ b/pkg/db/serialization/json_blob_test.go
@@ -2,6 +2,7 @@ package serialization
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -15,12 +16,26 @@ func TestJSONBlobScan(t *testing.T) {
 		err      string
 	}{
 		{
-			name: "Populates the underlying struct with values when source is valid",
+			name: "Populates the underlying struct with values when source is byte slice",
 			data: &struct{ Name string }{},
 			src:  []byte(`{"Name":"value"}`),
 			expected: &struct {
 				Name string
 			}{Name: "value"},
+		},
+		{
+			name: "Populates the underlying struct with values when source is string",
+			data: &struct{ Name string }{},
+			src:  `{"Name":"value"}`,
+			expected: &struct {
+				Name string
+			}{Name: "value"},
+		},
+		{
+			name:     "Support scanning nil",
+			data:     &struct{ Name string }{},
+			src:      nil,
+			expected: &struct{ Name string }{},
 		},
 		{
 			name: "Returns error when the source is not a valid JSON",
@@ -34,11 +49,11 @@ func TestJSONBlobScan(t *testing.T) {
 		{
 			name: "Returns error when the source is not a byte slice",
 			data: &struct{ Name string }{},
-			src:  `{"Name":"value"}`,
+			src:  time.Now(),
 			expected: &struct {
 				Name string
 			}{Name: "value"},
-			err: "source must be a byte slice",
+			err: "unknown json object type time.Time",
 		},
 	}
 


### PR DESCRIPTION
**What**
- Expand scan support so that nil and string values are supported, this provides better support for arbitrary blobs, which could be nil, e.g. in a join 

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>