### PR TITLE
Add help to retreive user claims from ctx

### DIFF
--- a/pkg/http/middlewares/authorization/claims.go
+++ b/pkg/http/middlewares/authorization/claims.go
@@ -116,7 +116,13 @@ func (a *Claims) Entities() (entities []string) {
 
 // GetClaims retrieves the Claims object from the request context
 func GetClaims(r *http.Request) (Claims, bool) {
-	claims, ok := r.Context().Value(authClaimsKey).(Claims)
+	claims, ok := GetClaimsFromCtx(r.Context())
+	return claims, ok
+}
+
+// GetClaimsFromCtx retrieves the Claims object from the given context
+func GetClaimsFromCtx(ctx context.Context) (Claims, bool) {
+	claims, ok := ctx.Value(authClaimsKey).(Claims)
 	return claims, ok
 }
 


### PR DESCRIPTION
**What**
- In the pgql server we need to retreive the user claims from an
  arbitrary context, not directly from a request object, because the
  request context and passed to the required location indirectly. This new helper
  supports that
Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>