### PR TITLE
Add Seal/Unseal and crypto token creation

### DIFF
--- a/pkg/crypto/encrypt.go
+++ b/pkg/crypto/encrypt.go
@@ -133,7 +133,11 @@ func Unseal(cipherText, key []byte) (plainText []byte, err error) {
 	plainText = messageAndMAC[:splitPoint]
 
 	mac := hmac.New(sha512.New512_256, key)
-	mac.Write(plainText)
+	// the doc says it never returns an error, but we don't trust it
+	_, err = mac.Write(plainText)
+	if err != nil {
+		return nil, err
+	}
 	expectedMAC := mac.Sum(nil)
 
 	if !hmac.Equal(expectedMAC, messageMAC) {

--- a/pkg/crypto/encrypt_test.go
+++ b/pkg/crypto/encrypt_test.go
@@ -17,7 +17,7 @@ func TestPassphraseToKey(t *testing.T) {
 	}
 }
 
-func Test_EncryptDecrypt(t *testing.T) {
+func TestEncryptDecrypt(t *testing.T) {
 	key := PassphraseToKey("some very secure passphrase no hacker can hack")
 	text := []byte("some very secret text to encrypt")
 
@@ -61,6 +61,63 @@ func Test_EncryptDecrypt(t *testing.T) {
 		_, err := Decrypt([]byte{0}, key)
 		if err != ErrCipherTooShort {
 			t.Fatal(err, "expected `ErrCipherTooShort`")
+		}
+	})
+}
+
+func TestSealUnseal(t *testing.T) {
+	key := PassphraseToKey("some very secure passphrase no hacker can hack")
+	text := []byte("some very secret text to encrypt")
+
+	t.Run("seals/unseals bytes", func(t *testing.T) {
+		cipherText, err := Seal(text, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Equal(text, cipherText) {
+			t.Fatal("cipher text must differ the original text")
+		}
+
+		plainText, err := Unseal(cipherText, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(text, plainText) {
+			t.Fatal("decrypted text must match the original text")
+		}
+	})
+
+	t.Run("seals/unseals a string", func(t *testing.T) {
+		cipherTextString, err := SealToString(text, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(text) == cipherTextString {
+			t.Fatal("cipher text must differ the original text")
+		}
+
+		plainText, err := UnsealFromString(cipherTextString, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(text, plainText) {
+			t.Fatal("decrypted text must match the original text")
+		}
+	})
+
+	t.Run("authenticates the message", func(t *testing.T) {
+		cipherText, err := Seal(text, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cipherText[1] = 'x'
+
+		plainText, err := Unseal(cipherText, key)
+		if err != ErrCorruptedMessage {
+			t.Fatal(err)
+		}
+		if len(plainText) != 0 {
+			t.Fatal("decrypted text must be empty in case of error")
 		}
 	})
 }

--- a/pkg/crypto/generate.go
+++ b/pkg/crypto/generate.go
@@ -1,10 +1,24 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/gob"
 	"encoding/hex"
+	"errors"
 	"io"
+	"time"
 )
+
+var (
+	// ErrTokenExpired occurs when the token lifetime is exceeded
+	ErrTokenExpired = errors.New("crypto: token expired")
+)
+
+type token struct {
+	Data      []byte
+	CreatedAt time.Time
+}
 
 // GenerateRandomString generates a random string with a given length
 func GenerateRandomString(length int) (string, error) {
@@ -19,4 +33,43 @@ func GenerateRandomString(length int) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(bytes)[0:length], nil
+}
+
+// GenerateToken generates a sealed token with a given ID and timestamp for
+// future verification.
+func GenerateToken(data, key []byte) (tokenStr string, err error) {
+	t := token{
+		Data:      data,
+		CreatedAt: time.Now(),
+	}
+	b := bytes.NewBuffer(nil)
+	enc := gob.NewEncoder(b)
+	err = enc.Encode(t)
+	if err != nil {
+		return "", err
+	}
+
+	return SealToString(b.Bytes(), key)
+}
+
+// DecodeAndVerify unseals the token and verifies its lifetime
+func DecodeAndVerifyToken(tokenStr string, key []byte, lifetime time.Duration) (data []byte, err error) {
+	plainText, err := UnsealFromString(tokenStr, key)
+	if err != nil {
+		return nil, err
+	}
+	b := bytes.NewBuffer(plainText)
+	dec := gob.NewDecoder(b)
+
+	var t token
+	err = dec.Decode(&t)
+	if err != nil {
+		return nil, err
+	}
+
+	if t.CreatedAt.Add(lifetime).Before(time.Now()) {
+		return nil, ErrTokenExpired
+	}
+
+	return t.Data, nil
 }

--- a/pkg/crypto/generate_test.go
+++ b/pkg/crypto/generate_test.go
@@ -1,6 +1,10 @@
 package crypto
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+	"time"
+)
 
 func TestRandomString(t *testing.T) {
 	t.Run("does not repeat the same value twice", func(t *testing.T) {
@@ -32,6 +36,44 @@ func TestRandomString(t *testing.T) {
 		}
 		if len(r1) != 15 {
 			t.Fatal("string length must be 15 characters")
+		}
+	})
+}
+
+func TestGenerateDecodeAndVerifyToken(t *testing.T) {
+	key := PassphraseToKey("some very secure passphrase no hacker can hack")
+	text := []byte("some very secret text to encrypt")
+
+	t.Run("preserves the data", func(t *testing.T) {
+		token, err := GenerateToken(text, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := DecodeAndVerifyToken(token, key, time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(text, data) {
+			t.Fatal("data does not match with the initial text")
+		}
+	})
+
+	t.Run("expires", func(t *testing.T) {
+		token, err := GenerateToken(text, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		<-time.After(2 * time.Second)
+
+		data, err := DecodeAndVerifyToken(token, key, time.Second)
+		if err != ErrTokenExpired {
+			t.Fatal(err)
+		}
+		if len(data) != 0 {
+			t.Fatal("data should be empty")
 		}
 	})
 }


### PR DESCRIPTION
Now it's possible to use Authenticated Encryption using
MAC-then-Encrypt (MtE) approach.

Also, now it's easier to create a state or CSRF token using
`GenerateToken` and then verify it using `DecodeAndVerifyToken`.