### PR TITLE
Introduce `SQLBuilder` interface

### DIFF
--- a/pkg/data/managers/base.go
+++ b/pkg/data/managers/base.go
@@ -30,9 +30,9 @@ type PageInfo struct {
 type BaseManager interface {
 	tracing.Tracer
 	// GetQueryBuilder creates a new squirrel builder for a SQL query
-	GetQueryBuilder() squirrel.StatementBuilderType
+	GetQueryBuilder() db.SQLBuilder
 	// GetTxQueryBuilder is the same as GetQueryBuilder but also opens a transaction
-	GetTxQueryBuilder(ctx context.Context, opts *sql.TxOptions) (squirrel.StatementBuilderType, *sql.Tx, error)
+	GetTxQueryBuilder(ctx context.Context, opts *sql.TxOptions) (db.SQLBuilder, *sql.Tx, error)
 	// GetPageInfo returns the page info object for a given page
 	//
 	// `scope` is the SQL where statement that defines the scope
@@ -56,13 +56,13 @@ type baseManager struct {
 	tracing.Tracer
 }
 
-func (m *baseManager) GetQueryBuilder() squirrel.StatementBuilderType {
+func (m *baseManager) GetQueryBuilder() db.SQLBuilder {
 	return squirrel.StatementBuilder.
 		PlaceholderFormat(squirrel.Dollar).
 		RunWith(db.WrapWithTracing(m.db))
 }
 
-func (m *baseManager) GetTxQueryBuilder(ctx context.Context, opts *sql.TxOptions) (squirrel.StatementBuilderType, *sql.Tx, error) {
+func (m *baseManager) GetTxQueryBuilder(ctx context.Context, opts *sql.TxOptions) (db.SQLBuilder, *sql.Tx, error) {
 	tx, err := m.db.BeginTx(ctx, opts)
 	return squirrel.StatementBuilder.
 		PlaceholderFormat(squirrel.Dollar).

--- a/pkg/data/managers/id_resolver.go
+++ b/pkg/data/managers/id_resolver.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	squirrel "github.com/Masterminds/squirrel"
+	"github.com/contiamo/go-base/pkg/db"
 	dserrors "github.com/contiamo/go-base/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
@@ -16,11 +17,11 @@ type IDResolver interface {
 	// Resolve returns an ID of the given record identified by the value which can be either
 	// an UUID or a unique string value of the given secondary column.
 	// where is a map of where statements to their list of arguments
-	Resolve(ctx context.Context, sql squirrel.StatementBuilderType, value string, filter squirrel.Sqlizer) (string, error)
+	Resolve(ctx context.Context, sql db.SQLBuilder, value string, filter squirrel.Sqlizer) (string, error)
 	// Sqlizer returns a Sqlizer interface that contains where statements for a given
 	// filter and the ID column, so you can immediately use it with
 	// the where of the select builder
-	Sqlizer(ctx context.Context, sql squirrel.StatementBuilderType, value string, filter squirrel.Sqlizer) (squirrel.Sqlizer, error)
+	Sqlizer(ctx context.Context, sql db.SQLBuilder, value string, filter squirrel.Sqlizer) (squirrel.Sqlizer, error)
 }
 
 // NewIDResolver creates a new name->id resolver for a table, for example
@@ -42,7 +43,7 @@ type idResolver struct {
 	secondaryColumn string
 }
 
-func (r *idResolver) Sqlizer(ctx context.Context, sql squirrel.StatementBuilderType, value string, filter squirrel.Sqlizer) (squirrel.Sqlizer, error) {
+func (r *idResolver) Sqlizer(ctx context.Context, sql db.SQLBuilder, value string, filter squirrel.Sqlizer) (squirrel.Sqlizer, error) {
 	id, err := r.Resolve(ctx, sql, value, filter)
 	if err != nil {
 		return nil, err
@@ -60,7 +61,7 @@ func (r *idResolver) Sqlizer(ctx context.Context, sql squirrel.StatementBuilderT
 	}, nil
 }
 
-func (r *idResolver) Resolve(ctx context.Context, sql squirrel.StatementBuilderType, value string, filter squirrel.Sqlizer) (string, error) {
+func (r *idResolver) Resolve(ctx context.Context, sql db.SQLBuilder, value string, filter squirrel.Sqlizer) (string, error) {
 	if value == "" {
 		return value, dserrors.ValidationErrors{
 			"id": errors.New("the id parameter can't be empty"),

--- a/pkg/db/builder.go
+++ b/pkg/db/builder.go
@@ -1,0 +1,22 @@
+package db
+
+import "github.com/Masterminds/squirrel"
+
+// SQLBuilder describes a basic SQL builder using the squirrel library
+type SQLBuilder interface {
+
+	// Select returns a SelectBuilder
+	Select(columns ...string) squirrel.SelectBuilder
+
+	// Insert returns a InsertBuilder
+	Insert(into string) squirrel.InsertBuilder
+
+	// Update returns a UpdateBuilder
+	Update(table string) squirrel.UpdateBuilder
+
+	// Delete returns a DeleteBuilder
+	Delete(from string) squirrel.DeleteBuilder
+
+	// RunWith sets the RunWith field for any child builders.
+	RunWith(runner squirrel.BaseRunner) squirrel.StatementBuilderType
+}


### PR DESCRIPTION
So, there is no direct dependency to a structure type. It's more
convenient in certain situations for us to have an interface that
can be `nil`.