### PR TITLE
Revert "only use a single query to get the page infos. (#25)"

### DIFF
--- a/pkg/data/managers/base.go
+++ b/pkg/data/managers/base.go
@@ -3,8 +3,6 @@ package managers
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"strings"
 
 	"github.com/Masterminds/squirrel"
 
@@ -81,56 +79,35 @@ func (m *baseManager) GetPageInfo(ctx context.Context, table string, page parame
 	span.SetTag("pageInfo.curent", pageInfo.Current)
 	span.SetTag("pageInfo.itemsPerPage", pageInfo.ItemsPerPage)
 
-	filterSQL := "1 = 1"
-	filterArgs := []interface{}{}
-	if filter != nil {
-		filterSQL, filterArgs, err = filter.ToSql()
-		if err != nil {
-			return pageInfo, err
-		}
-	}
+	builder := m.GetQueryBuilder()
 
-	scopeSQL := "1 = 1"
-	scopeArgs := []interface{}{}
-	if scope != nil {
-		scopeSQL, scopeArgs, err = scope.ToSql()
-		if err != nil {
-			return pageInfo, err
-		}
-	}
-
-	query := replaceQuestionMarks(fmt.Sprintf(`
-SELECT COUNT(*) AS unfilteredItemCount, SUM(hit) AS itemCount FROM (
-  SELECT
-    *,
-    (CASE WHEN (%s) THEN 1 ELSE 0 END) AS hit
-  FROM %s
-  WHERE %s
-) AS subquery`, filterSQL, table, scopeSQL))
-
-	args := append(filterArgs, scopeArgs...)
-	row := m.db.QueryRowContext(ctx, query, args...)
-	err = row.Scan(&pageInfo.UnfilteredItemCount, &pageInfo.ItemCount)
+	err = builder.
+		Select("COUNT(*)").
+		From(table).
+		Where(scope).
+		QueryRowContext(ctx).
+		Scan(&pageInfo.UnfilteredItemCount)
 	if err != nil {
 		return pageInfo, err
+	}
+
+	if filter != nil {
+		err = builder.
+			Select("COUNT(*)").
+			From(table).
+			Where(scope).
+			Where(filter).
+			QueryRowContext(ctx).
+			Scan(&pageInfo.ItemCount)
+		if err != nil {
+			return pageInfo, err
+		}
+	} else {
+		pageInfo.ItemCount = pageInfo.UnfilteredItemCount
 	}
 
 	span.SetTag("pageInfo.itemCount", pageInfo.ItemCount)
 	span.SetTag("pageInfo.unfilteredItemCount", pageInfo.UnfilteredItemCount)
 
 	return pageInfo, err
-}
-
-func replaceQuestionMarks(query string) string {
-	res := query
-	i := 1
-	for {
-		next := strings.Replace(res, "?", fmt.Sprintf("$%d", i), 1)
-		if next == res {
-			break
-		}
-		i++
-		res = next
-	}
-	return res
 }


### PR DESCRIPTION
This reverts commit aecc07f648dfc55201fe0fcf33bc0390920dca64.

This change breaks the existing code in Hub.