### PR TITLE
Replace strings with UUID wherever needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/golang/protobuf v1.3.2
-	github.com/google/uuid v1.1.1
+	github.com/google/uuid v1.1.1 // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/pkg/crypto/generate.go
+++ b/pkg/crypto/generate.go
@@ -35,7 +35,7 @@ func GenerateRandomString(length int) (string, error) {
 	return hex.EncodeToString(bytes)[0:length], nil
 }
 
-// GenerateToken generates a sealed token with a given ID and timestamp for
+// GenerateToken generates a sealed token with a given data
 // future verification.
 func GenerateToken(data, key []byte) (tokenStr string, err error) {
 	t := token{

--- a/pkg/data/managers/id_resolver_test.go
+++ b/pkg/data/managers/id_resolver_test.go
@@ -73,27 +73,27 @@ func Test_Resolve(t *testing.T) {
 
 	cases := []struct {
 		name,
-		value,
-		expectedID string
-		where  squirrel.Sqlizer
-		expErr bool
+		value string
+		where      squirrel.Sqlizer
+		expectedID uuid.UUID
+		expErr     bool
 	}{
 		{
 			name:       "Resolves UUID into ID",
 			value:      ids[0].String(),
-			expectedID: ids[0].String(),
+			expectedID: ids[0],
 			where:      nil,
 		},
 		{
 			name:       "Resolves a unique name into ID",
 			value:      "unique",
-			expectedID: ids[0].String(),
+			expectedID: ids[0],
 			where:      nil,
 		},
 		{
 			name:       "Resolves a non-unique name into ID for different parent IDs",
 			value:      "regular",
-			expectedID: ids[1].String(),
+			expectedID: ids[1],
 			where: squirrel.Eq{
 				"parent_id": secIDs[0],
 			},
@@ -101,7 +101,7 @@ func Test_Resolve(t *testing.T) {
 		{
 			name:       "Resolves a second non-unique name into ID",
 			value:      "regular",
-			expectedID: ids[2].String(),
+			expectedID: ids[2],
 			where: squirrel.Eq{
 				"parent_id": secIDs[1],
 			},
@@ -109,7 +109,7 @@ func Test_Resolve(t *testing.T) {
 		{
 			name:       "Triggers error when resolve a non-existent name",
 			value:      "wrong",
-			expectedID: "",
+			expectedID: uuid.Nil,
 			where: squirrel.Eq{
 				"parent_id": secIDs[0],
 			},
@@ -118,7 +118,7 @@ func Test_Resolve(t *testing.T) {
 		{
 			name:       "Triggers error when there are more than one result",
 			value:      "regular",
-			expectedID: "",
+			expectedID: uuid.Nil,
 			expErr:     true,
 		},
 		{

--- a/pkg/http/middlewares/authorization/claims.go
+++ b/pkg/http/middlewares/authorization/claims.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/contiamo/jwt"
-	"github.com/google/uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // authContextKey is an unexported type for keys defined in middleware.
@@ -23,7 +23,7 @@ var (
 	authClaimsKey = authContextKey("DatastoreClaims")
 	// DataStoreClaims used for setting the service itself as an author of a record
 	DataStoreClaims = Claims{
-		UserID:   uuid.Nil.String(),
+		UserID:   uuid.Nil,
 		UserName: "datastore",
 	}
 )
@@ -49,28 +49,31 @@ var (
 // 	AdminRealmIDs    []string `protobuf:"bytes,15,rep,name=AdminRealmIDs,json=adminRealmIDs,proto3" json:"AdminRealmIDs,omitempty"`
 // }
 type Claims struct {
-	ID               string    `json:"id"`
-	IssuedAt         Timestamp `json:"iat"`
-	NotBefore        Timestamp `json:"nbf"`
-	Expires          Timestamp `json:"exp"`
-	Issuer           string    `json:"iss"`
-	UserID           string    `json:"sub"`
-	UserName         string    `json:"name"`
-	TenantID         string    `json:"tenantID"`
-	Email            string    `json:"email"`
-	RealmIDs         []string  `json:"realmIDs"`
-	GroupIDs         []string  `json:"groupIDs"`
-	ResourceTokenIDs []string  `json:"resourceTokenIDs"`
-	AllowedIPs       []string  `json:"allowedIPs"`
-	IsTenantAdmin    bool      `json:"isTenantAdmin"`
-	AdminRealmIDs    []string  `json:"adminRealmIDs"`
-	SourceToken      string    `json:"-"`
+	ID               uuid.UUID   `json:"id"`
+	UserID           uuid.UUID   `json:"sub"`
+	TenantID         uuid.UUID   `json:"tenantID"`
+	RealmIDs         []uuid.UUID `json:"realmIDs"`
+	GroupIDs         []uuid.UUID `json:"groupIDs"`
+	ResourceTokenIDs []uuid.UUID `json:"resourceTokenIDs"`
+	AdminRealmIDs    []uuid.UUID `json:"adminRealmIDs"`
+
+	IssuedAt      Timestamp `json:"iat"`
+	NotBefore     Timestamp `json:"nbf"`
+	Expires       Timestamp `json:"exp"`
+	Issuer        string    `json:"iss"`
+	UserName      string    `json:"name"`
+	Email         string    `json:"email"`
+	AllowedIPs    []string  `json:"allowedIPs"`
+	IsTenantAdmin bool      `json:"isTenantAdmin"`
+
+	SourceToken string `json:"-"`
 }
 
 // Valid tests if the Claims object contains the minimal required information
 // to be used for authorization checks.
 func (a *Claims) Valid() bool {
-	return a.UserID != "" || len(a.ResourceTokenIDs) > 0
+
+	return a.UserID != uuid.Nil || len(a.ResourceTokenIDs) > 0
 }
 
 // FromClaimsMap loads the claim information from a jwt.Claims object, this is a simple
@@ -107,7 +110,7 @@ func (a *Claims) ToJWT(privateKey interface{}) (string, error) {
 
 // Entities returns a slice of the entity ids that the auth claims contains.  These are ids
 // that permissions may be assigned to. Currently, this is the UserID, GroupIDs, and ResourceTokenIDs
-func (a *Claims) Entities() (entities []string) {
+func (a *Claims) Entities() (entities []uuid.UUID) {
 	entities = append(entities, a.UserID)
 	entities = append(entities, a.GroupIDs...)
 	entities = append(entities, a.ResourceTokenIDs...)

--- a/pkg/http/middlewares/path.go
+++ b/pkg/http/middlewares/path.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi"
-	"github.com/google/uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // PathWithCleanID replace string values that look like ids (uuids and int) with "*"
 func PathWithCleanID(r *http.Request) string {
 	pathParts := strings.Split(r.URL.Path, "/")
 	for i, part := range pathParts {
-		if _, err := uuid.Parse(part); err == nil {
+		if _, err := uuid.FromString(part); err == nil {
 			pathParts[i] = "*"
 			continue
 		}
@@ -30,7 +30,7 @@ func PathWithCleanID(r *http.Request) string {
 func MethodAndPathCleanID(r *http.Request) string {
 	pathParts := strings.Split(r.URL.Path, "/")
 	for i, part := range pathParts {
-		if _, err := uuid.Parse(part); err == nil {
+		if _, err := uuid.FromString(part); err == nil {
 			pathParts[i] = "*"
 			continue
 		}


### PR DESCRIPTION
We should be stricter about typing of ID values if we know for sure
that the value is always a UUID. This change breaks backwards
compatibility and requries a major release.

* name -> UUID resolution now always returns a UUID
* claims work with UUIDs instead of strings for all ID values
* removed `github.com/google/uuid` as a direct dependency in `path` middleware.