### PR TITLE
Revert v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/golang/protobuf v1.3.2
-	github.com/google/uuid v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/contiamo/go-base/v2
+module github.com/contiamo/go-base
 
 require (
 	github.com/Masterminds/squirrel v1.1.0

--- a/pkg/crypto/generate.go
+++ b/pkg/crypto/generate.go
@@ -35,7 +35,7 @@ func GenerateRandomString(length int) (string, error) {
 	return hex.EncodeToString(bytes)[0:length], nil
 }
 
-// GenerateToken generates a sealed token with a given data
+// GenerateToken generates a sealed token with a given ID and timestamp for
 // future verification.
 func GenerateToken(data, key []byte) (tokenStr string, err error) {
 	t := token{

--- a/pkg/data/managers/base.go
+++ b/pkg/data/managers/base.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/Masterminds/squirrel"
 
-	"github.com/contiamo/go-base/v2/pkg/db"
-	"github.com/contiamo/go-base/v2/pkg/http/parameters"
-	"github.com/contiamo/go-base/v2/pkg/tracing"
+	"github.com/contiamo/go-base/pkg/db"
+	"github.com/contiamo/go-base/pkg/http/parameters"
+	"github.com/contiamo/go-base/pkg/tracing"
 )
 
 // PageInfo - Contains the pagination metadata for a response

--- a/pkg/data/managers/base_test.go
+++ b/pkg/data/managers/base_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/Masterminds/squirrel"
-	dbtest "github.com/contiamo/go-base/v2/pkg/db/test"
-	"github.com/contiamo/go-base/v2/pkg/http/parameters"
+	dbtest "github.com/contiamo/go-base/pkg/db/test"
+	"github.com/contiamo/go-base/pkg/http/parameters"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/data/managers/id_resolver.go
+++ b/pkg/data/managers/id_resolver.go
@@ -17,7 +17,7 @@ type IDResolver interface {
 	// Resolve returns an ID of the given record identified by the value which can be either
 	// an UUID or a unique string value of the given secondary column.
 	// where is a map of where statements to their list of arguments
-	Resolve(ctx context.Context, sql db.SQLBuilder, value string, filter squirrel.Sqlizer) (uuid.UUID, error)
+	Resolve(ctx context.Context, sql db.SQLBuilder, value string, filter squirrel.Sqlizer) (string, error)
 	// Sqlizer returns a Sqlizer interface that contains where statements for a given
 	// filter and the ID column, so you can immediately use it with
 	// the where of the select builder
@@ -61,16 +61,16 @@ func (r *idResolver) Sqlizer(ctx context.Context, sql db.SQLBuilder, value strin
 	}, nil
 }
 
-func (r *idResolver) Resolve(ctx context.Context, sql db.SQLBuilder, value string, filter squirrel.Sqlizer) (uuid.UUID, error) {
+func (r *idResolver) Resolve(ctx context.Context, sql db.SQLBuilder, value string, filter squirrel.Sqlizer) (string, error) {
 	if value == "" {
-		return uuid.Nil, dserrors.ValidationErrors{
+		return value, dserrors.ValidationErrors{
 			"id": errors.New("the id parameter can't be empty"),
 		}.Filter()
 	}
 
 	uuidVal, err := uuid.FromString(strings.TrimSpace(value))
 	if err == nil {
-		return uuidVal, nil
+		return uuidVal.String(), nil
 	}
 
 	rows, err := sql.
@@ -82,23 +82,23 @@ func (r *idResolver) Resolve(ctx context.Context, sql db.SQLBuilder, value strin
 		QueryContext(ctx)
 
 	if err != nil {
-		return uuid.Nil, err
+		return "", err
 	}
 
 	defer rows.Close()
 
 	// no results at all
 	if !rows.Next() {
-		return uuid.Nil, dserrors.ErrNotFound
+		return "", dserrors.ErrNotFound
 	}
-	var id uuid.UUID
+	var id string
 	err = rows.Scan(&id)
 	if err != nil {
 		return id, err
 	}
 	// non-unique result
 	if rows.Next() {
-		return uuid.Nil, fmt.Errorf(
+		return "", fmt.Errorf(
 			"id for `%s = %s` can't be resolved in `%s` due to non-unique results",
 			r.secondaryColumn,
 			value,

--- a/pkg/data/managers/id_resolver.go
+++ b/pkg/data/managers/id_resolver.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	squirrel "github.com/Masterminds/squirrel"
-	"github.com/contiamo/go-base/v2/pkg/db"
-	dserrors "github.com/contiamo/go-base/v2/pkg/errors"
+	"github.com/contiamo/go-base/pkg/db"
+	dserrors "github.com/contiamo/go-base/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/pkg/data/managers/id_resolver_test.go
+++ b/pkg/data/managers/id_resolver_test.go
@@ -73,27 +73,27 @@ func Test_Resolve(t *testing.T) {
 
 	cases := []struct {
 		name,
-		value string
-		where      squirrel.Sqlizer
-		expectedID uuid.UUID
-		expErr     bool
+		value,
+		expectedID string
+		where  squirrel.Sqlizer
+		expErr bool
 	}{
 		{
 			name:       "Resolves UUID into ID",
 			value:      ids[0].String(),
-			expectedID: ids[0],
+			expectedID: ids[0].String(),
 			where:      nil,
 		},
 		{
 			name:       "Resolves a unique name into ID",
 			value:      "unique",
-			expectedID: ids[0],
+			expectedID: ids[0].String(),
 			where:      nil,
 		},
 		{
 			name:       "Resolves a non-unique name into ID for different parent IDs",
 			value:      "regular",
-			expectedID: ids[1],
+			expectedID: ids[1].String(),
 			where: squirrel.Eq{
 				"parent_id": secIDs[0],
 			},
@@ -101,7 +101,7 @@ func Test_Resolve(t *testing.T) {
 		{
 			name:       "Resolves a second non-unique name into ID",
 			value:      "regular",
-			expectedID: ids[2],
+			expectedID: ids[2].String(),
 			where: squirrel.Eq{
 				"parent_id": secIDs[1],
 			},
@@ -109,7 +109,7 @@ func Test_Resolve(t *testing.T) {
 		{
 			name:       "Triggers error when resolve a non-existent name",
 			value:      "wrong",
-			expectedID: uuid.Nil,
+			expectedID: "",
 			where: squirrel.Eq{
 				"parent_id": secIDs[0],
 			},
@@ -118,7 +118,7 @@ func Test_Resolve(t *testing.T) {
 		{
 			name:       "Triggers error when there are more than one result",
 			value:      "regular",
-			expectedID: uuid.Nil,
+			expectedID: "",
 			expErr:     true,
 		},
 		{

--- a/pkg/data/managers/id_resolver_test.go
+++ b/pkg/data/managers/id_resolver_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	squirrel "github.com/Masterminds/squirrel"
-	dbtest "github.com/contiamo/go-base/v2/pkg/db/test"
+	dbtest "github.com/contiamo/go-base/pkg/db/test"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"

--- a/pkg/db/open.go
+++ b/pkg/db/open.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 
 	"github.com/cenkalti/backoff"
-	"github.com/contiamo/go-base/v2/pkg/config"
+	"github.com/contiamo/go-base/pkg/config"
 )
 
 // Open opens a connection to a database and retries until ctx.Done()

--- a/pkg/db/test/db.go
+++ b/pkg/db/test/db.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/Masterminds/squirrel"
-	"github.com/contiamo/go-base/v2/pkg/config"
-	cdb "github.com/contiamo/go-base/v2/pkg/db"
+	"github.com/contiamo/go-base/pkg/config"
+	cdb "github.com/contiamo/go-base/pkg/db"
 
 	// since this test helper is going to be used in tests the CLI would not initialize
 	// the drivers for us, so we need to put it here again

--- a/pkg/db/tracing.go
+++ b/pkg/db/tracing.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/contiamo/go-base/v2/pkg/tracing"
+	"github.com/contiamo/go-base/pkg/tracing"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/http/handlers/base.go
+++ b/pkg/http/handlers/base.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"strings"
 
-	cerrors "github.com/contiamo/go-base/v2/pkg/errors"
-	"github.com/contiamo/go-base/v2/pkg/tracing"
+	cerrors "github.com/contiamo/go-base/pkg/errors"
+	"github.com/contiamo/go-base/pkg/tracing"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/http/handlers/base_test.go
+++ b/pkg/http/handlers/base_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	cerrors "github.com/contiamo/go-base/v2/pkg/errors"
+	cerrors "github.com/contiamo/go-base/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/http/middlewares/authorization/claims.go
+++ b/pkg/http/middlewares/authorization/claims.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/contiamo/jwt"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 // authContextKey is an unexported type for keys defined in middleware.
@@ -23,7 +23,7 @@ var (
 	authClaimsKey = authContextKey("DatastoreClaims")
 	// DataStoreClaims used for setting the service itself as an author of a record
 	DataStoreClaims = Claims{
-		UserID:   uuid.Nil,
+		UserID:   uuid.Nil.String(),
 		UserName: "datastore",
 	}
 )
@@ -49,31 +49,28 @@ var (
 // 	AdminRealmIDs    []string `protobuf:"bytes,15,rep,name=AdminRealmIDs,json=adminRealmIDs,proto3" json:"AdminRealmIDs,omitempty"`
 // }
 type Claims struct {
-	ID               uuid.UUID   `json:"id"`
-	UserID           uuid.UUID   `json:"sub"`
-	TenantID         uuid.UUID   `json:"tenantID"`
-	RealmIDs         []uuid.UUID `json:"realmIDs"`
-	GroupIDs         []uuid.UUID `json:"groupIDs"`
-	ResourceTokenIDs []uuid.UUID `json:"resourceTokenIDs"`
-	AdminRealmIDs    []uuid.UUID `json:"adminRealmIDs"`
-
-	IssuedAt      Timestamp `json:"iat"`
-	NotBefore     Timestamp `json:"nbf"`
-	Expires       Timestamp `json:"exp"`
-	Issuer        string    `json:"iss"`
-	UserName      string    `json:"name"`
-	Email         string    `json:"email"`
-	AllowedIPs    []string  `json:"allowedIPs"`
-	IsTenantAdmin bool      `json:"isTenantAdmin"`
-
-	SourceToken string `json:"-"`
+	ID               string    `json:"id"`
+	IssuedAt         Timestamp `json:"iat"`
+	NotBefore        Timestamp `json:"nbf"`
+	Expires          Timestamp `json:"exp"`
+	Issuer           string    `json:"iss"`
+	UserID           string    `json:"sub"`
+	UserName         string    `json:"name"`
+	TenantID         string    `json:"tenantID"`
+	Email            string    `json:"email"`
+	RealmIDs         []string  `json:"realmIDs"`
+	GroupIDs         []string  `json:"groupIDs"`
+	ResourceTokenIDs []string  `json:"resourceTokenIDs"`
+	AllowedIPs       []string  `json:"allowedIPs"`
+	IsTenantAdmin    bool      `json:"isTenantAdmin"`
+	AdminRealmIDs    []string  `json:"adminRealmIDs"`
+	SourceToken      string    `json:"-"`
 }
 
 // Valid tests if the Claims object contains the minimal required information
 // to be used for authorization checks.
 func (a *Claims) Valid() bool {
-
-	return a.UserID != uuid.Nil || len(a.ResourceTokenIDs) > 0
+	return a.UserID != "" || len(a.ResourceTokenIDs) > 0
 }
 
 // FromClaimsMap loads the claim information from a jwt.Claims object, this is a simple
@@ -110,7 +107,7 @@ func (a *Claims) ToJWT(privateKey interface{}) (string, error) {
 
 // Entities returns a slice of the entity ids that the auth claims contains.  These are ids
 // that permissions may be assigned to. Currently, this is the UserID, GroupIDs, and ResourceTokenIDs
-func (a *Claims) Entities() (entities []uuid.UUID) {
+func (a *Claims) Entities() (entities []string) {
 	entities = append(entities, a.UserID)
 	entities = append(entities, a.GroupIDs...)
 	entities = append(entities, a.ResourceTokenIDs...)

--- a/pkg/http/middlewares/authorization/middleware.go
+++ b/pkg/http/middlewares/authorization/middleware.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httputil"
 	"strings"
 
-	"github.com/contiamo/go-base/v2/pkg/tracing"
+	"github.com/contiamo/go-base/pkg/tracing"
 	goserverhttp "github.com/contiamo/goserver/http"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"

--- a/pkg/http/middlewares/cors.go
+++ b/pkg/http/middlewares/cors.go
@@ -3,7 +3,7 @@ package middlewares
 import (
 	"net/http"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 
 	"github.com/rs/cors"
 )

--- a/pkg/http/middlewares/cors_test.go
+++ b/pkg/http/middlewares/cors_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/http/middlewares/logging.go
+++ b/pkg/http/middlewares/logging.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 )
 
 // WithLogging configures a logrus middleware for that server

--- a/pkg/http/middlewares/logging_test.go
+++ b/pkg/http/middlewares/logging_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
-	utils "github.com/contiamo/go-base/v2/pkg/testing"
+	server "github.com/contiamo/go-base/pkg/http"
+	utils "github.com/contiamo/go-base/pkg/testing"
 )
 
 func Test_LoggingMiddleware(t *testing.T) {

--- a/pkg/http/middlewares/metrics.go
+++ b/pkg/http/middlewares/metrics.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/urfave/negroni"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/pkg/http/middlewares/metrics_test.go
+++ b/pkg/http/middlewares/metrics_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 )
 
 func Test_MetricsMiddleware(t *testing.T) {

--- a/pkg/http/middlewares/middleware_test.go
+++ b/pkg/http/middlewares/middleware_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 )
 
 var upgrader = websocket.Upgrader{}

--- a/pkg/http/middlewares/path.go
+++ b/pkg/http/middlewares/path.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 // PathWithCleanID replace string values that look like ids (uuids and int) with "*"
 func PathWithCleanID(r *http.Request) string {
 	pathParts := strings.Split(r.URL.Path, "/")
 	for i, part := range pathParts {
-		if _, err := uuid.FromString(part); err == nil {
+		if _, err := uuid.Parse(part); err == nil {
 			pathParts[i] = "*"
 			continue
 		}
@@ -30,7 +30,7 @@ func PathWithCleanID(r *http.Request) string {
 func MethodAndPathCleanID(r *http.Request) string {
 	pathParts := strings.Split(r.URL.Path, "/")
 	for i, part := range pathParts {
-		if _, err := uuid.FromString(part); err == nil {
+		if _, err := uuid.Parse(part); err == nil {
 			pathParts[i] = "*"
 			continue
 		}

--- a/pkg/http/middlewares/recovery.go
+++ b/pkg/http/middlewares/recovery.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	recovery "github.com/bakins/net-http-recover"
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 )
 
 // WithRecovery configures panic recovery for that server

--- a/pkg/http/middlewares/recovery_test.go
+++ b/pkg/http/middlewares/recovery_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 )
 
 func Test_RecoveryMiddleware(t *testing.T) {

--- a/pkg/http/middlewares/tracing.go
+++ b/pkg/http/middlewares/tracing.go
@@ -7,8 +7,8 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/urfave/negroni"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
-	"github.com/contiamo/go-base/v2/pkg/tracing"
+	server "github.com/contiamo/go-base/pkg/http"
+	"github.com/contiamo/go-base/pkg/tracing"
 )
 
 // mainly from "github.com/opentracing-contrib/go-stdlib/nethttp"

--- a/pkg/http/middlewares/tracing_test.go
+++ b/pkg/http/middlewares/tracing_test.go
@@ -10,7 +10,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 
-	server "github.com/contiamo/go-base/v2/pkg/http"
+	server "github.com/contiamo/go-base/pkg/http"
 )
 
 func Test_TracingMiddleware(t *testing.T) {

--- a/pkg/http/parameters/test/resolver.go
+++ b/pkg/http/parameters/test/resolver.go
@@ -3,7 +3,7 @@ package test
 import (
 	"net/http"
 
-	"github.com/contiamo/go-base/v2/pkg/http/parameters"
+	"github.com/contiamo/go-base/pkg/http/parameters"
 )
 
 // NewMockResolver creates a new mock resolver with the predefined value


### PR DESCRIPTION
Revert the v2 release because it caused a huge amount of work to migrate to UUID-based API.