### PR TITLE
Allow passing multiple init method for GetDatabase

### DIFF
--- a/pkg/data/managers/id_resolver_test.go
+++ b/pkg/data/managers/id_resolver_test.go
@@ -21,7 +21,7 @@ func init() {
 func Test_Sqlizer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	_, db := dbtest.GetDatabase(t, nil)
+	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
 
 	r := NewIDResolver("test", "id", "name")

--- a/pkg/db/serialization/null/time.go
+++ b/pkg/db/serialization/null/time.go
@@ -39,7 +39,7 @@ func (nt Time) String() string {
 	if !nt.Valid {
 		return "null"
 	}
-	return nt.Time.String()
+	return nt.Time.Format("2006-01-02 15:04:05 -0700 MST")
 }
 
 // MarshalJSON marshalls Time to the primitive value `null` or the RFC3339

--- a/pkg/db/test/db.go
+++ b/pkg/db/test/db.go
@@ -44,7 +44,7 @@ func EqualCount(t *testing.T, db *sql.DB, expected int, table string, filter squ
 }
 
 // GetDatabase gets a test database
-func GetDatabase(t *testing.T, init DBInitializer) (name string, testDB *sql.DB) {
+func GetDatabase(t *testing.T, inits ...DBInitializer) (name string, testDB *sql.DB) {
 	var err error
 	defer func() {
 		if testDB == nil {
@@ -60,13 +60,19 @@ func GetDatabase(t *testing.T, init DBInitializer) (name string, testDB *sql.DB)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if init == nil {
+	if inits == nil {
 		return name, testDB
 	}
-	err = init(ctx, testDB)
-	if err != nil {
-		t.Fatalf("Can't initialize the database `%s`: %v", name, err)
-		return "", nil
+	for _, init := range inits {
+		// for backwards compatibility
+		if init == nil {
+			continue
+		}
+		err = init(ctx, testDB)
+		if err != nil {
+			t.Fatalf("Can't initialize the database `%s`: %v", name, err)
+			return "", nil
+		}
 	}
 	return name, testDB
 }


### PR DESCRIPTION
**What**
- Allow passing multiple init methods for the test GetDatabase method
- Fix NullTime string formatting consistency

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>