### PR TITLE
order routes before creating the template context in the router generation.

### DIFF
--- a/pkg/generators/router/router.go
+++ b/pkg/generators/router/router.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -98,13 +99,23 @@ type spec struct {
 	Paths map[string]path `yaml:"paths"`
 }
 
+func getSortedKeys(pathObj map[string]path) (keys []string) {
+	keys = make([]string, 0, len(pathObj))
+	for key := range pathObj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func createTemplateCtx(spec spec, opts Options) (out templateCtx, err error) {
 	out.PackageName = opts.PackageName
 	out.Spec = spec
 	out.Groups = make(map[string]*handlerGroup)
 	out.PathsByGroups = make(map[string]*pathsInGroup)
 
-	for path, definition := range spec.Paths {
+	for _, path := range getSortedKeys(spec.Paths) {
+		definition := spec.Paths[path]
 		err = setEndpoint(&out, opts, http.MethodGet, path, definition.GET)
 		if err != nil {
 			return out, err

--- a/pkg/generators/router/router_test.go
+++ b/pkg/generators/router/router_test.go
@@ -162,7 +162,14 @@ func TestCreateTemplateCtx(t *testing.T) {
 					Group:       "Group",
 				},
 			},
-			"/another/path": path{},
+			"/another/path": path{
+				GET: &endpoint{
+					Summary:     "GET Summary",
+					Description: "GET Description",
+					OperationID: "AnotherGETOperationID",
+					Group:       "Group",
+				},
+			},
 		},
 	}
 
@@ -174,6 +181,7 @@ func TestCreateTemplateCtx(t *testing.T) {
 		Groups: map[string]*handlerGroup{
 			"Group": &handlerGroup{
 				Endpoints: []endpoint{
+					*spec.Paths["/another/path"].GET,
 					*spec.Paths["/some/path"].GET,
 					*spec.Paths["/some/path"].POST,
 					*spec.Paths["/some/path"].PUT,
@@ -192,6 +200,11 @@ func TestCreateTemplateCtx(t *testing.T) {
 							"PUT":    "PUTOperationID",
 							"PATCH":  "PATCHOperationID",
 							"DELETE": "DELETEOperationID",
+						},
+					},
+					"/another/path": &methodsInPath{
+						OperationsByMethods: map[string]string{
+							"GET": "AnotherGETOperationID",
 						},
 					},
 				},


### PR DESCRIPTION
It just annoyed me that the router always looks different when we need to regenerate it.

Simple fix, so we can include it in the next release.