### PR TITLE
Ensure Max open connections is set during open

### DIFF
--- a/pkg/db/open.go
+++ b/pkg/db/open.go
@@ -29,5 +29,7 @@ func Open(ctx context.Context, cfg config.Database) (db *sql.DB, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	db.SetMaxOpenConns(cfg.PoolSize)
 	return db, nil
 }


### PR DESCRIPTION
**What**
- Set the db pool max open connections limit as soon as we open the db
  this ensures the value is always set

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>