### PR TITLE
add queue code.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lib/pq v1.1.1
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
@@ -30,9 +29,9 @@ require (
 	github.com/uber/jaeger-client-go v2.16.0+incompatible
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect
 	github.com/urfave/negroni v1.0.0
+	go.uber.org/goleak v1.0.0
 	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 // indirect
 	google.golang.org/grpc v1.22.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=
@@ -165,6 +166,8 @@ github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
+go.uber.org/goleak v1.0.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 golang.org/x/crypto v0.0.0-20180411161317-d6449816ce06/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -175,6 +178,8 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180418062111-d41e8174641f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d h1:g9qWBGx4puODJTMVyoPrpoxPFgVGd+z1DZwjfRu4d0I=
@@ -185,6 +190,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -208,6 +215,9 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2gOy6m5uvpg+ISQoEcusQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11 h1:Yq9t9jnGoR+dBuitxdo9l6Q7xh/zOyNnYUtDKaQ3x0E=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/pkg/config/queue.go
+++ b/pkg/config/queue.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"time"
+)
+
+// Queue contains configuation for task queueing
+type Queue struct {
+	// HeartbeatTTL is the max time a worker is expected to call queue.Heartbeat when processing a task
+	HeartbeatTTL time.Duration `json:"heartbeatTTL"`
+	// PollFrequency is the polling frequency when the queue will check for a new task for a waiting worker
+	PollFrequency time.Duration `json:"pollFrequency"`
+	// JobSchedulingInterval is the interval between iterations of the worker (e.g. job scheduling)
+	SchedulingInterval time.Duration `json:"schedulingInterval"`
+	// Minimal time between two listener reconnects
+	MinReconnectTimeout time.Duration `json:"minReconnectTimeout"`
+	// Maximal time between two listener reconnects
+	MaxReconnectTimeout time.Duration `json:"maxReconnectTimeout"`
+}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -1,0 +1,105 @@
+package queue
+
+import (
+	"context"
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// ErrTaskCancelled is used to notify the worker from the Heartbeat that the task
+	// was cancelled by the user and it needs to stop working on it.
+	ErrTaskCancelled = errors.New("task has been cancelled")
+	// ErrTaskFinished is used to notify the worker from the Heartbeat that the task has
+	// already finished and can't be worked on
+	ErrTaskFinished = errors.New("task has finished")
+	// ErrTaskNotRunning is used to notify the worker from the Heartbeat that the task has
+	// not started yet and can't be worked on
+	ErrTaskNotRunning = errors.New("task has not started yet")
+	// ErrTaskNotFound is used to notify the worker from the Heartbeat that the task does not
+	// exist
+	ErrTaskNotFound = errors.New("task not found")
+	// ErrTaskFailed indicates that a task has failed and should not be restarted
+	ErrTaskFailed = errors.New("task failed")
+	// ErrTaskQueueNotSpecified indicates that the given task cannot be enqueued because
+	// the queue name is empty
+	ErrTaskQueueNotSpecified = errors.New("task queue name cannot be blank")
+	// ErrTaskTypeNotSpecified indicates that the given task cannot be enqueued because
+	// the task type is empty
+	ErrTaskTypeNotSpecified = errors.New("task type cannot be blank")
+)
+
+// Queuer is a write-only interface for the queue
+type Queuer interface {
+	// Enqueue adds a task to the provided queue within the Task object
+	Enqueue(ctx context.Context, task TaskEnqueueRequest) error
+}
+
+// Dequeuer is a read only interface for the queue
+type Dequeuer interface {
+	// Dequeue removes a task for processing from the provided queue
+	// It's expected to block until work is available
+	//
+	// For zero-length queue parameter, dequeue should return a task from a random queue;
+	// otherwise dequeue should return a task from the supplied list of queues.
+	Dequeue(ctx context.Context, queue ...string) (*Task, error)
+
+	// Heartbeat updates the task to ensure that it's still being processed by a worker.
+	//
+	// Once a task has begun processing, 'Heartbeat' should be called at known
+	// intervals to update the 'Progress' and 'LastHeartbeat' fields.
+	// This provides a way to determine if the worker is still processing.
+	Heartbeat(ctx context.Context, taskID string, progress Progress) error
+
+	// Finish marks the task as completed
+	// It's recommended to update the progress to a final state to ensure there is
+	// no ambiguity in whether or not the task is complete
+	Finish(ctx context.Context, taskID string, progress Progress) error
+
+	// Finish marks the task as failed
+	// It's recommended to update the progress to a final state.
+	Fail(ctx context.Context, taskID string, progress Progress) error
+}
+
+type queuerWithMetrics struct {
+	q Queuer
+}
+
+// QueuerWithMetrics returns q wrapped with the standard metrics implementation
+func QueuerWithMetrics(q Queuer) Queuer {
+	return &queuerWithMetrics{q}
+}
+
+func (q *queuerWithMetrics) Enqueue(ctx context.Context, task TaskEnqueueRequest) error {
+	TaskQueueMetrics.TaskCounter.With(prometheus.Labels{"queue": task.Queue, "type": task.Type.String()}).Inc()
+	timer := prometheus.NewTimer(TaskQueueMetrics.EnqueueDuration.With(prometheus.Labels{"queue": task.Queue}))
+	defer timer.ObserveDuration()
+
+	return q.q.Enqueue(ctx, task)
+}
+
+type dequeuerWithMetrics struct {
+	q Dequeuer
+}
+
+// DequeuerWithMetrics returns q wrapped with the standard metrics implementation
+func DequeuerWithMetrics(q Dequeuer) Dequeuer {
+	return &dequeuerWithMetrics{q}
+}
+
+func (q *dequeuerWithMetrics) Dequeue(ctx context.Context, queue ...string) (*Task, error) {
+	return q.q.Dequeue(ctx, queue...)
+}
+
+func (q *dequeuerWithMetrics) Heartbeat(ctx context.Context, taskID string, progress Progress) error {
+	return q.q.Heartbeat(ctx, taskID, progress)
+}
+
+func (q *dequeuerWithMetrics) Finish(ctx context.Context, taskID string, progress Progress) error {
+	return q.q.Finish(ctx, taskID, progress)
+}
+
+func (q *dequeuerWithMetrics) Fail(ctx context.Context, taskID string, progress Progress) error {
+	return q.q.Fail(ctx, taskID, progress)
+}

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -1,0 +1,48 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestQueueMetrics(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	numOfTasks := 2
+	qCh := make(chan *Task, numOfTasks)
+	rawQ := QueueMock{Queue: qCh}
+	q := QueuerWithMetrics(&rawQ)
+
+	testTask := TaskEnqueueRequest{TaskBase: TaskBase{Queue: "testQueue", Type: "tester"}}
+	promLabels := prometheus.Labels{"queue": testTask.Queue, "type": testTask.Type.String()}
+
+	t.Run("task count starts at 0", func(t *testing.T) {
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskQueueMetrics.TaskCounter.With(promLabels)))
+	})
+
+	for i := 0; i < numOfTasks; i++ {
+		err := q.Enqueue(ctx, testTask)
+		require.NoError(t, err)
+	}
+
+	time.Sleep(time.Millisecond)
+	t.Run("task count inc after enqueueing a task", func(t *testing.T) {
+		// compairing with the rawQ count ensures that the underlying queue was called by our wrapping method
+		require.Equal(t, numOfTasks, rawQ.EnqueueCount)
+		require.Equal(t, float64(rawQ.EnqueueCount), testutil.ToFloat64(TaskQueueMetrics.TaskCounter.With(promLabels)))
+	})
+
+	t.Run("metrics wrapped queue calls the internal queue method", func(t *testing.T) {
+		actualTask := <-qCh
+		require.Equal(t, testTask.Type, actualTask.Type)
+		require.Equal(t, testTask.Queue, actualTask.Queue)
+	})
+}

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -15,6 +15,8 @@ func TestQueueMetrics(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	SetupTaskQueueMetrics("test")
+	SetupSchedulerMetrics("test")
 
 	numOfTasks := 2
 	qCh := make(chan *Task, numOfTasks)

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -9,60 +11,83 @@ import (
 var durationMsBuckets = []float64{10, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000}
 
 var (
-	queueMetricLabels = []string{"queue"}
-	taskMetricLabels  = []string{"queue", "type"}
+	queueMetricLabels        = []string{"queue"}
+	taskMetricLabels         = []string{"queue", "type"}
+	oneTaskQueueMetricsSetup sync.Once
+	oneSchedulerMetricsSetup sync.Once
 )
 
-// TaskQueueMetrics provides access to the prometheus metric objects for the task queue
-var TaskQueueMetrics = struct {
+// TaskQueueMetricsType provides access to the prometheus metric objects for the task queue
+type TaskQueueMetricsType struct {
 	Labels          []string
 	TaskCounter     *prometheus.CounterVec
 	EnqueueDuration *prometheus.HistogramVec
-}{
-	Labels: queueMetricLabels,
-	TaskCounter: promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "hub",
-			Subsystem: "queue",
-			Name:      "task",
-			Help:      "count of tasks that have been enqueued",
-		},
-		taskMetricLabels,
-	),
-	EnqueueDuration: promauto.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "hub",
-			Subsystem: "queue",
-			Name:      "enqueue_duration_ms",
-			Help:      "duration the enqueue action in ms",
-			Buckets:   durationMsBuckets,
-		},
-		queueMetricLabels,
-	),
 }
 
-var SchedulerMetrics = struct {
+// TaskQueueMetrics is the global metrics instance for the task queue of this instance
+var TaskQueueMetrics TaskQueueMetricsType
+
+// SetupTaskQueueMetrics must be called before any other call to the metric subsystem happens
+func SetupTaskQueueMetrics(namespace string) {
+	oneTaskQueueMetricsSetup.Do(func() {
+		TaskQueueMetrics = TaskQueueMetricsType{
+			Labels: queueMetricLabels,
+			TaskCounter: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: namespace,
+					Subsystem: "queue",
+					Name:      "task",
+					Help:      "count of tasks that have been enqueued",
+				},
+				taskMetricLabels,
+			),
+			EnqueueDuration: promauto.NewHistogramVec(
+				prometheus.HistogramOpts{
+					Namespace: namespace,
+					Subsystem: "queue",
+					Name:      "enqueue_duration_ms",
+					Help:      "duration the enqueue action in ms",
+					Buckets:   durationMsBuckets,
+				},
+				queueMetricLabels,
+			),
+		}
+	})
+}
+
+// TaskQueueMetricsType provides access to the prometheus metric objects for the scheduler
+type SchedulerMetricsType struct {
 	Labels          []string
 	ScheduleCounter *prometheus.CounterVec
 	ErrorCounter    *prometheus.CounterVec
-}{
-	Labels: queueMetricLabels,
-	ScheduleCounter: promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "hub",
-			Subsystem: "scheduler",
-			Name:      "task",
-			Help:      "count of tasks that have been scheduled",
-		},
-		taskMetricLabels,
-	),
-	ErrorCounter: promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "hub",
-			Subsystem: "scheduler",
-			Name:      "error",
-			Help:      "count of errors while scheduling",
-		},
-		taskMetricLabels,
-	),
+}
+
+// SchedulerMetrics is the global metrics instance for the scheduler of this instance
+var SchedulerMetrics SchedulerMetricsType
+
+// SetupSchedulerMetrics must be called before any other call to the metric subsystem happens
+func SetupSchedulerMetrics(namespace string) {
+	oneSchedulerMetricsSetup.Do(func() {
+		SchedulerMetrics = SchedulerMetricsType{
+			Labels: queueMetricLabels,
+			ScheduleCounter: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: namespace,
+					Subsystem: "scheduler",
+					Name:      "task",
+					Help:      "count of tasks that have been scheduled",
+				},
+				taskMetricLabels,
+			),
+			ErrorCounter: promauto.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: namespace,
+					Subsystem: "scheduler",
+					Name:      "error",
+					Help:      "count of errors while scheduling",
+				},
+				taskMetricLabels,
+			),
+		}
+	})
 }

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -1,0 +1,68 @@
+package queue
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// largest bucket is 5 seconds
+var durationMsBuckets = []float64{10, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000}
+
+var (
+	queueMetricLabels = []string{"queue"}
+	taskMetricLabels  = []string{"queue", "type"}
+)
+
+// TaskQueueMetrics provides access to the prometheus metric objects for the task queue
+var TaskQueueMetrics = struct {
+	Labels          []string
+	TaskCounter     *prometheus.CounterVec
+	EnqueueDuration *prometheus.HistogramVec
+}{
+	Labels: queueMetricLabels,
+	TaskCounter: promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hub",
+			Subsystem: "queue",
+			Name:      "task",
+			Help:      "count of tasks that have been enqueued",
+		},
+		taskMetricLabels,
+	),
+	EnqueueDuration: promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "hub",
+			Subsystem: "queue",
+			Name:      "enqueue_duration_ms",
+			Help:      "duration the enqueue action in ms",
+			Buckets:   durationMsBuckets,
+		},
+		queueMetricLabels,
+	),
+}
+
+var SchedulerMetrics = struct {
+	Labels          []string
+	ScheduleCounter *prometheus.CounterVec
+	ErrorCounter    *prometheus.CounterVec
+}{
+	Labels: queueMetricLabels,
+	ScheduleCounter: promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hub",
+			Subsystem: "scheduler",
+			Name:      "task",
+			Help:      "count of tasks that have been scheduled",
+		},
+		taskMetricLabels,
+	),
+	ErrorCounter: promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hub",
+			Subsystem: "scheduler",
+			Name:      "error",
+			Help:      "count of errors while scheduling",
+		},
+		taskMetricLabels,
+	),
+}

--- a/pkg/queue/mock_test.go
+++ b/pkg/queue/mock_test.go
@@ -1,0 +1,73 @@
+package queue
+
+import (
+	"context"
+
+	cdb "github.com/contiamo/go-base/pkg/db"
+)
+
+// QueueMock implements queue with very simple counters for testing
+type QueueMock struct {
+	Queue          chan *Task
+	DequeueErr     error
+	HeartbeatErr   error
+	FinishErr      error
+	EnqueueCount   int
+	DequeueCount   int
+	HeartbeatCount int
+	FinishCount    int
+}
+
+// Enqueue implements queue Manager for testing
+func (q *QueueMock) Enqueue(ctx context.Context, task TaskEnqueueRequest) error {
+	q.EnqueueCount = q.EnqueueCount + 1
+	q.Queue <- &Task{TaskBase: task.TaskBase}
+	return nil
+}
+
+// Dequeue implements queue Manager for testing
+func (q *QueueMock) Dequeue(ctx context.Context, queue ...string) (*Task, error) {
+	q.DequeueCount = q.DequeueCount + 1
+	if q.DequeueErr != nil {
+		return nil, q.DequeueErr
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case t := <-q.Queue:
+		return t, nil
+	}
+
+}
+
+// Heartbeat implements queue Manager for testing
+func (q *QueueMock) Heartbeat(ctx context.Context, taskID string, progress Progress) error {
+	q.HeartbeatCount = q.HeartbeatCount + 1
+	return q.HeartbeatErr
+}
+
+// Finish implements queue Manager for testing
+func (q *QueueMock) Finish(ctx context.Context, taskID string, progress Progress, isFailed bool) error {
+	q.FinishCount = q.FinishCount + 1
+	return q.FinishErr
+}
+
+// SchedulerMock implement scheduler with very simple counters for testing
+type SchedulerMock struct {
+	ScheduleErr   error
+	ScheduleCount int
+
+	EnsureError error
+	EnsureCount int
+}
+
+func (s *SchedulerMock) Schedule(ctx context.Context, builder cdb.SQLBuilder, task TaskScheduleRequest) (err error) {
+	s.ScheduleCount = s.ScheduleCount + 1
+	return s.ScheduleErr
+}
+
+func (s *SchedulerMock) EnsureSchedule(ctx context.Context, builder cdb.SQLBuilder, task TaskScheduleRequest) error {
+	s.EnsureCount = s.EnsureCount + 1
+	return s.EnsureError
+}

--- a/pkg/queue/postgres/dequeuer.go
+++ b/pkg/queue/postgres/dequeuer.go
@@ -1,0 +1,448 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"math/rand"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/contiamo/go-base/pkg/data/managers"
+	cdb "github.com/contiamo/go-base/pkg/db"
+	"github.com/contiamo/go-base/pkg/queue"
+	"github.com/lib/pq"
+
+	"github.com/contiamo/go-base/pkg/config"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// NewDequeuer creates a new postgres queue dequeuer
+func NewDequeuer(db *sql.DB, dbListener *pq.Listener, cfg config.Queue) queue.Dequeuer {
+	return &dequeuer{
+		BaseManager: managers.NewBaseManager(db, "PostgresDequeuer"),
+		cfg:         cfg,
+		listener:    dbListener,
+	}
+}
+
+// NewDequeuerWithMetrics creates a new postgres queue dequeuer with the default metrics enabled
+func NewDequeuerWithMetrics(db *sql.DB, dbListener *pq.Listener, cfg config.Queue) queue.Dequeuer {
+	return queue.DequeuerWithMetrics(NewDequeuer(db, dbListener, cfg))
+}
+
+// dequeuer is a postgres-backed implementation of the queue Dequeuer
+type dequeuer struct {
+	cfg      config.Queue
+	listener *pq.Listener
+	managers.BaseManager
+}
+
+// Dequeue implements queue.Dequeue
+// It's expected to block until work is available
+// Allows only one task per queue to be worked on at once
+// Returns the oldest task in the queue that hasn't started or has had a failure
+func (q *dequeuer) Dequeue(ctx context.Context, queues ...string) (task *queue.Task, err error) {
+	span, ctx := q.StartSpan(ctx, "Dequeue")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	span.SetTag("queues", queues)
+
+	// if nil, nil is returned, no tasks are available so we will continue to call the db
+	// until a task or error is received
+	task, err = q.attemptDequeue(ctx, queues...)
+
+	if task == nil && err == nil {
+		err = q.listener.Listen("task_update")
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			unlistenError := q.listener.Unlisten("task_update")
+			if unlistenError != nil && err == nil {
+				err = unlistenError
+			}
+		}()
+		ticker := time.NewTicker(q.cfg.PollFrequency)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-ticker.C:
+				logrus.Debug("attempt dequeue because of ticker")
+				task, err = q.attemptDequeue(ctx, queues...)
+				if task != nil || err != nil {
+					return task, err
+				}
+				err = q.listener.Ping()
+				if err != nil {
+					return nil, err
+				}
+			case <-q.listener.Notify:
+				logrus.Debug("attempt dequeue because of notification")
+				task, err = q.attemptDequeue(ctx, queues...)
+				if task != nil || err != nil {
+					return task, err
+				}
+				err = q.listener.Ping()
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return task, err
+}
+
+func (q *dequeuer) attemptDequeue(ctx context.Context, queues ...string) (task *queue.Task, err error) {
+	span, ctx := q.StartSpan(ctx, "attemptDequeue")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	now := time.Now()
+	doubleTTL := now.Add(-2 * q.cfg.HeartbeatTTL) // assume a task has failed if there's no heartbeat after twice the ttl
+
+	builder, tx, err := q.GetTxQueryBuilder(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			err = errors.Wrap(err, rollbackErr.Error())
+		}
+	}()
+
+	// if zero length q is passed in, get a list of all queues with unfinished tasks
+	if len(queues) == 0 {
+		queues, err = q.generateUnfinishedQueueList(ctx, builder)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	inflight, err := q.generateInflightQueueList(ctx, doubleTTL)
+	if err != nil {
+		return nil, err
+	}
+
+	processableQs := processableQueues(inflight, queues)
+
+	span.SetTag("queue.inflightQueues", len(inflight))
+	span.SetTag("queue.potentialQueues", len(processableQs))
+
+	// no tasks available
+	if len(processableQs) == 0 {
+		return nil, nil
+	}
+
+	// choose a random queue
+	n := rand.Intn(len(processableQs))
+	queueName := processableQs[n]
+	logrus.Debugf("choosing random queue `%s`", queueName)
+
+	// find the oldest non-started or failed task
+	row := builder.
+		Select(q.columns()...).
+		From("tasks").
+		Where(squirrel.Or{
+			squirrel.Eq{"queue": queueName, "started_at": nil},
+			squirrel.And{
+				squirrel.Eq{"queue": queueName, "finished_at": nil},
+				squirrel.Lt{"last_heartbeat_at": doubleTTL},
+			},
+		}).
+		OrderBy("created_at DESC").
+		Limit(1).
+		Suffix("FOR UPDATE").
+		QueryRowContext(ctx)
+
+	task, err = q.scan(row)
+	if err == sql.ErrNoRows {
+		logrus.Debugf("queue `%s` does not have an available task", queueName)
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	span.SetTag("task.timeSpentWaiting", now.Sub(task.CreatedAt))
+
+	// update started_at time
+	_, err = builder.
+		Update("tasks").
+		Set("started_at", now).
+		Set("last_heartbeat_at", now).
+		Set("status", queue.Running).
+		Where("task_id=?", task.ID).
+		ExecContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	task.StartedAt = &now
+	task.LastHeartbeatAt = &now
+	return task, err
+}
+
+func (q *dequeuer) Heartbeat(ctx context.Context, taskID string, progress queue.Progress) (err error) {
+	span, ctx := q.StartSpan(ctx, "Heartbeat")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+	span.SetTag("task.ID", taskID)
+	span.SetTag("progress", string(progress))
+	err = q.updateProgress(ctx, taskID, progress, false, false)
+
+	return err
+}
+
+func (q *dequeuer) Finish(ctx context.Context, taskID string, progress queue.Progress) (err error) {
+	span, ctx := q.StartSpan(ctx, "Finish")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	span.SetTag("task.ID", taskID)
+	span.SetTag("progress", string(progress))
+
+	err = q.updateProgress(ctx, taskID, progress, true, false)
+
+	return err
+}
+
+func (q *dequeuer) Fail(ctx context.Context, taskID string, progress queue.Progress) (err error) {
+	span, ctx := q.StartSpan(ctx, "Fail")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	span.SetTag("task.ID", taskID)
+	span.SetTag("progress", string(progress))
+
+	err = q.updateProgress(ctx, taskID, progress, true, true)
+
+	return err
+}
+
+func (q *dequeuer) updateProgress(ctx context.Context, taskID string, progress queue.Progress, isFinal, isFailed bool) (err error) {
+	span, ctx := q.StartSpan(ctx, "updateProgress")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	// debug log the progress update because we had a really bad bug were we tried to write an
+	// empty progress. This debug statement may be the other content we get in on prem
+	logrus.
+		WithField("method", "updateProgress").
+		WithField("task", taskID).
+		WithField("isFinal", isFinal).
+		WithField("isFailed", isFailed).
+		Debug(string(progress))
+
+	// ensure that progress is always a valid JSON object
+	if len(progress) == 0 {
+		progress = emptyJSON
+	}
+
+	builder, tx, err := q.GetTxQueryBuilder(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			err = errors.Wrap(err, rollbackErr.Error())
+		}
+	}()
+
+	now := time.Now()
+
+	var status queue.TaskStatus
+	err = builder.
+		Select("status").
+		From("tasks").
+		Where("task_id = ?", taskID).
+		Suffix("FOR UPDATE").
+		QueryRowContext(ctx).
+		Scan(&status)
+
+	if err == sql.ErrNoRows {
+		return queue.ErrTaskNotFound
+	}
+	if err != nil {
+		return err
+	}
+
+	// we should proceed ONLY if the task is actually running
+	switch status {
+	case queue.Waiting:
+		return queue.ErrTaskNotRunning
+	case queue.Cancelled:
+		return queue.ErrTaskCancelled
+	case queue.Finished:
+		return queue.ErrTaskFinished
+	}
+
+	stmt := builder.
+		Update("tasks").
+		Set("last_heartbeat_at", now).
+		Set("progress", progress).
+		Where("task_id = ?", taskID)
+
+	switch {
+	case isFinal && isFailed:
+		stmt = stmt.Set("finished_at", now).Set("status", queue.Failed)
+	case isFinal && !isFailed:
+		stmt = stmt.Set("finished_at", now).Set("status", queue.Finished)
+	case !isFinal && isFailed:
+		stmt = stmt.Set("status", queue.Failed)
+	case !isFinal && !isFailed:
+		stmt = stmt.Set("status", queue.Running)
+	}
+
+	_, err = stmt.ExecContext(ctx)
+
+	return err
+}
+
+func (q *dequeuer) columns() []string {
+	return []string{
+		"task_id",
+		"queue",
+		"type",
+		"spec",
+		"status",
+		"progress",
+		"created_at",
+		"updated_at",
+		"started_at",
+		"finished_at",
+		"last_heartbeat_at",
+	}
+}
+
+func (q *dequeuer) scan(row squirrel.RowScanner) (task *queue.Task, err error) {
+	var t queue.Task
+	err = row.Scan(
+		&t.ID,
+		&t.Queue,
+		&t.Type,
+		&t.Spec,
+		&t.Status,
+		&t.Progress,
+		&t.CreatedAt,
+		&t.UpdatedAt,
+		&t.StartedAt,
+		&t.FinishedAt,
+		&t.LastHeartbeatAt,
+	)
+	if err == nil {
+		task = &t
+		// ensure that we always have at least an empty json object
+		if len(task.Progress) == 0 {
+			task.Progress = emptyJSON
+		}
+		if len(task.Spec) == 0 {
+			task.Spec = emptyJSON
+		}
+	}
+
+	return task, err
+}
+
+// generateUnfinishedQueueList returns a distinct list of queues with unfinished tasks
+func (q *dequeuer) generateUnfinishedQueueList(ctx context.Context, builder cdb.SQLBuilder) (queueList []string, err error) {
+	span, ctx := q.StartSpan(ctx, "generateUnfinishedQueueList")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	where := squirrel.Eq{
+		"finished_at": nil,
+	}
+
+	return q.generateQueueList(ctx, where)
+}
+
+// generateInflightQueueList returns a distinct list of queues with tasks that are currently inflight
+func (q *dequeuer) generateInflightQueueList(ctx context.Context, beforeDoubleTTL time.Time) (queueList []string, err error) {
+	span, ctx := q.StartSpan(ctx, "generateInflightQueueList")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	where := squirrel.And{
+		squirrel.Gt{"last_heartbeat_at": beforeDoubleTTL},
+		squirrel.Eq{"finished_at": nil},
+	}
+
+	return q.generateQueueList(ctx, where)
+}
+
+// generateQueueList returns a distinct list of queues
+func (q *dequeuer) generateQueueList(ctx context.Context, where squirrel.Sqlizer) (queueList []string, err error) {
+	span, ctx := q.StartSpan(ctx, "generateQueueList")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	rows, err := q.GetQueryBuilder().
+		Select("queue").
+		Distinct().
+		From("tasks").
+		Where(where).
+		QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var q string
+		err = rows.Scan(&q)
+		if err != nil {
+			return nil, err
+		}
+
+		queueList = append(queueList, q)
+	}
+
+	span.SetTag("queue.list", queueList)
+
+	return queueList, nil
+}
+
+// processableQueues removes all inflight items from potential items
+func processableQueues(inflight, potential []string) []string {
+	inflightMap := make(map[string]bool, len(inflight))
+	for _, s := range inflight {
+		inflightMap[s] = true
+	}
+	var processableQs []string
+	for _, s := range potential {
+		_, ok := inflightMap[s]
+		if !ok {
+			processableQs = append(processableQs, s)
+		}
+	}
+
+	return processableQs
+}

--- a/pkg/queue/postgres/dequeuer_test.go
+++ b/pkg/queue/postgres/dequeuer_test.go
@@ -28,7 +28,7 @@ func TestFinish(t *testing.T) {
 
 	name, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, db, nil))
+	require.NoError(t, Setup(ctx, "test", db, nil))
 
 	taskID := uuid.NewV4().String()
 	connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
@@ -95,7 +95,7 @@ func TestFail(t *testing.T) {
 
 	name, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, db, nil))
+	require.NoError(t, Setup(ctx, "test", db, nil))
 
 	taskID := uuid.NewV4().String()
 
@@ -211,7 +211,7 @@ func TestHeartbeat(t *testing.T) {
 
 	name, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, db, nil))
+	require.NoError(t, Setup(ctx, "test", db, nil))
 
 	connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
 	dbListener := pq.NewListener(
@@ -352,7 +352,7 @@ func TestDequeueTicker(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			name, db := dbtest.GetDatabase(t)
 			defer db.Close()
-			require.NoError(t, Setup(ctx, db, nil))
+			require.NoError(t, Setup(ctx, "test", db, nil))
 
 			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
 			dbListener := pq.NewListener(
@@ -477,7 +477,7 @@ func TestDequeue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			name, db := dbtest.GetDatabase(t)
 			defer db.Close()
-			require.NoError(t, Setup(ctx, db, nil))
+			require.NoError(t, Setup(ctx, "test", db, nil))
 
 			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
 			dbListener := pq.NewListener(
@@ -630,7 +630,7 @@ func TestQueueList(t *testing.T) {
 
 			name, db := dbtest.GetDatabase(t)
 			defer db.Close()
-			require.NoError(t, Setup(ctx, db, nil))
+			require.NoError(t, Setup(ctx, "test", db, nil))
 			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
 			dbListener := pq.NewListener(
 				connStr,

--- a/pkg/queue/postgres/dequeuer_test.go
+++ b/pkg/queue/postgres/dequeuer_test.go
@@ -1,0 +1,683 @@
+package postgres
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/contiamo/go-base/pkg/config"
+	"github.com/contiamo/go-base/pkg/data/managers"
+	dbtest "github.com/contiamo/go-base/pkg/db/test"
+	"github.com/contiamo/go-base/pkg/queue"
+	"github.com/lib/pq"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinish(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, Setup(ctx, db, nil))
+
+	taskID := uuid.NewV4().String()
+	connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
+	dbListener := pq.NewListener(
+		connStr,
+		10*time.Second,
+		time.Minute,
+		func(ev pq.ListenerEventType, err error) {
+			if err != nil {
+				logrus.Error(err)
+			}
+		},
+	)
+
+	q := NewDequeuer(db, dbListener, config.Queue{
+		HeartbeatTTL:  10 * time.Second,
+		PollFrequency: 50 * time.Millisecond,
+	})
+
+	builder := squirrel.StatementBuilder.
+		PlaceholderFormat(squirrel.Dollar).
+		RunWith(db)
+
+	_, err := builder.
+		Insert("tasks").
+		Columns(
+			"task_id",
+			"queue",
+			"type",
+			"spec",
+			"progress",
+			"status",
+		).
+		Values(
+			taskID,
+			queueID1,
+			"test",
+			emptyJSON,
+			emptyJSON,
+			queue.Running,
+		).
+		ExecContext(ctx)
+
+	t.Run("sets the progress, finished status and finished timestamp", func(t *testing.T) {
+		err = q.Finish(ctx, taskID, progress)
+		require.NoError(t, err)
+		dbtest.EqualCount(t, db, 1, "tasks", squirrel.And{
+			squirrel.Eq{
+				"task_id":  taskID,
+				"status":   queue.Finished,
+				"progress": progress,
+			},
+			squirrel.NotEq{"finished_at": nil},
+		})
+	})
+}
+
+func TestFail(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, Setup(ctx, db, nil))
+
+	taskID := uuid.NewV4().String()
+
+	connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
+	dbListener := pq.NewListener(
+		connStr,
+		10*time.Second,
+		time.Minute,
+		func(ev pq.ListenerEventType, err error) {
+			if err != nil {
+				logrus.Error(err)
+			}
+		},
+	)
+
+	q := NewDequeuer(db, dbListener, config.Queue{
+		HeartbeatTTL:  10 * time.Second,
+		PollFrequency: 50 * time.Millisecond,
+	})
+
+	builder := squirrel.StatementBuilder.
+		PlaceholderFormat(squirrel.Dollar).
+		RunWith(db)
+
+	_, err := builder.
+		Insert("tasks").
+		Columns(
+			"task_id",
+			"queue",
+			"type",
+			"spec",
+			"progress",
+			"status",
+		).
+		Values(
+			taskID,
+			queueID1,
+			"test",
+			emptyJSON,
+			emptyJSON,
+			queue.Running,
+		).
+		ExecContext(ctx)
+
+	t.Run("sets the progress, failed status and finished timestamp", func(t *testing.T) {
+		err = q.Fail(ctx, taskID, progress)
+		require.NoError(t, err)
+		dbtest.EqualCount(t, db, 1, "tasks", squirrel.And{
+			squirrel.Eq{
+				"task_id":  taskID,
+				"status":   queue.Failed,
+				"progress": progress,
+			},
+			squirrel.NotEq{"finished_at": nil},
+		})
+	})
+}
+
+func TestHeartbeat(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	waitingUUID := uuid.NewV4().String()
+	runningUUID := uuid.NewV4().String()
+	finishedUUID := uuid.NewV4().String()
+	cancelledUUID := uuid.NewV4().String()
+	failedUUID := uuid.NewV4().String()
+
+	cases := []struct {
+		name     string
+		taskID   string
+		progress queue.Progress
+		expError string
+	}{
+		{
+			name:     "returns an error when the task is not found",
+			taskID:   uuid.NewV4().String(),
+			progress: progress,
+			expError: queue.ErrTaskNotFound.Error(),
+		},
+		{
+			name:     "update un-finished task",
+			taskID:   runningUUID,
+			progress: progress,
+		},
+		{
+			name:     "update task to finished",
+			taskID:   runningUUID,
+			progress: progress,
+		},
+		{
+			name:     "update finished task throws an error",
+			taskID:   finishedUUID,
+			progress: progress,
+			expError: queue.ErrTaskFinished.Error(),
+		},
+		{
+			name:     "update cancelled task throws an error",
+			taskID:   cancelledUUID,
+			progress: progress,
+			expError: queue.ErrTaskCancelled.Error(),
+		},
+		{
+			name:     "update waiting task throws an error",
+			taskID:   waitingUUID,
+			progress: progress,
+			expError: queue.ErrTaskNotRunning.Error(),
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	name, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, Setup(ctx, db, nil))
+
+	connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
+	dbListener := pq.NewListener(
+		connStr,
+		10*time.Second,
+		time.Minute,
+		func(ev pq.ListenerEventType, err error) {
+			if err != nil {
+				logrus.Error(err)
+			}
+		},
+	)
+
+	q := NewDequeuer(db, dbListener, config.Queue{
+		HeartbeatTTL:  10 * time.Second,
+		PollFrequency: 50 * time.Millisecond,
+	})
+
+	builder := squirrel.StatementBuilder.
+		PlaceholderFormat(squirrel.Dollar).
+		RunWith(db)
+
+	_, err := builder.
+		Insert("tasks").
+		Columns(
+			"task_id",
+			"queue",
+			"type",
+			"spec",
+			"progress",
+			"status",
+		).
+		Values(
+			runningUUID,
+			queueID1,
+			"test",
+			emptyJSON,
+			emptyJSON,
+			queue.Running,
+		).
+		Values(
+			waitingUUID,
+			queueID1,
+			"test",
+			emptyJSON,
+			emptyJSON,
+			queue.Waiting,
+		).
+		Values(
+			finishedUUID,
+			queueID2,
+			"test",
+			emptyJSON,
+			emptyJSON,
+			queue.Finished,
+		).
+		Values(
+			cancelledUUID,
+			queueID2,
+			"test",
+			emptyJSON,
+			emptyJSON,
+			queue.Cancelled,
+		).
+		Values(
+			failedUUID,
+			queueID2,
+			"test",
+			emptyJSON,
+			emptyJSON,
+			queue.Running,
+		).
+		ExecContext(ctx)
+
+	require.NoError(t, err)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := q.Heartbeat(ctx, tc.taskID, tc.progress)
+
+			if tc.expError != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.expError, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+
+			var (
+				beat     *time.Time
+				status   string
+				progress []byte
+			)
+			err = managers.NewBaseManager(db, "").GetQueryBuilder().
+				Select(
+					"last_heartbeat_at",
+					"status",
+					"progress",
+				).
+				From("tasks").
+				Where("task_id = ?", tc.taskID).
+				QueryRow().
+				Scan(&beat, &status, &progress)
+
+			require.NoError(t, err)
+			require.NotNil(t, beat)
+			require.Equal(t, string(queue.Running), status)
+			require.Equal(t, string(tc.progress), string(progress))
+		})
+	}
+}
+
+func TestDequeueTicker(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tests := []struct {
+		name  string
+		queue string
+		wait  time.Duration // pause before inserting a task into the db
+	}{
+		{
+			name:  "available task no blocking",
+			queue: queueID1,
+			wait:  0,
+		},
+		{
+			name:  "available task blocking",
+			queue: queueID2,
+			wait:  150 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, db := dbtest.GetDatabase(t)
+			defer db.Close()
+			require.NoError(t, Setup(ctx, db, nil))
+
+			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
+			dbListener := pq.NewListener(
+				connStr,
+				10*time.Second,
+				time.Minute,
+				func(ev pq.ListenerEventType, err error) {
+					if err != nil {
+						logrus.Error(err)
+					}
+				},
+			)
+
+			q := NewDequeuer(db, dbListener, config.Queue{
+				HeartbeatTTL:  10 * time.Second,
+				PollFrequency: 50 * time.Millisecond,
+			})
+
+			go func() {
+				time.Sleep(tt.wait)
+				builder := squirrel.StatementBuilder.
+					PlaceholderFormat(squirrel.Dollar).
+					RunWith(db)
+
+				_, err := builder.Insert("tasks").
+					Columns(
+						"task_id",
+						"queue",
+						"type",
+						"spec",
+						"progress",
+						"status",
+						"created_at",
+					).
+					Values(
+						uuid.NewV4(),
+						tt.queue,
+						"test",
+						emptyJSON,
+						emptyJSON,
+						queue.Waiting,
+						time.Now(),
+					).
+					ExecContext(ctx)
+
+				require.NoError(t, err)
+			}()
+
+			// to ensure that we have the insert in the db, wait for 20 ms before calling Dequeue
+			time.Sleep(20 * time.Millisecond)
+
+			task, err := q.Dequeue(ctx, tt.queue)
+			require.NoError(t, err)
+			require.NotNil(t, task)
+		})
+	}
+}
+
+func TestDequeue(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	now := time.Now()
+	old := time.Now().Add(-10 * time.Minute)
+
+	cases := []struct {
+		name     string
+		queue    string
+		tasks    []queue.Task
+		expError bool
+		expTask  bool
+	}{
+		{
+			name:  "queue has no tasks in db",
+			queue: queueID1,
+		},
+		{
+			name:    "queue has one task waiting",
+			queue:   queueID1,
+			tasks:   []queue.Task{{}},
+			expTask: true,
+		},
+		{
+			name:  "queue has one working task and no others available",
+			queue: queueID1,
+			tasks: []queue.Task{{StartedAt: &now, LastHeartbeatAt: &now}},
+		},
+
+		{
+			name:  "queue has one working task and one available",
+			queue: queueID1,
+			tasks: []queue.Task{
+				{StartedAt: &now, LastHeartbeatAt: &now},
+				{},
+			},
+		},
+		{
+			name:    "queue has one failed task",
+			queue:   queueID1,
+			tasks:   []queue.Task{{StartedAt: &old, LastHeartbeatAt: &old}},
+			expTask: true,
+		},
+		{
+			name:  "queue has one finished task",
+			queue: queueID1,
+			tasks: []queue.Task{{StartedAt: &old, LastHeartbeatAt: &old, FinishedAt: &old}},
+		},
+		{
+			name:  "queue has one finished task and one running task",
+			queue: queueID1,
+			tasks: []queue.Task{
+				{StartedAt: &old, LastHeartbeatAt: &old, FinishedAt: &old},
+				{StartedAt: &now, LastHeartbeatAt: &now},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name, db := dbtest.GetDatabase(t)
+			defer db.Close()
+			require.NoError(t, Setup(ctx, db, nil))
+
+			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
+			dbListener := pq.NewListener(
+				connStr,
+				10*time.Second,
+				time.Minute,
+				func(ev pq.ListenerEventType, err error) {
+					if err != nil {
+						logrus.Error(err)
+					}
+				},
+			)
+
+			q := NewDequeuer(db, dbListener, config.Queue{
+				HeartbeatTTL:  10 * time.Second,
+				PollFrequency: 50 * time.Millisecond,
+			})
+
+			builder := squirrel.StatementBuilder.
+				PlaceholderFormat(squirrel.Dollar).
+				RunWith(db)
+
+			for _, task := range tc.tasks {
+				_, err := builder.Insert("tasks").
+					Columns(
+						"task_id",
+						"queue",
+						"type",
+						"spec",
+						"progress",
+						"status",
+						"started_at",
+						"last_heartbeat_at",
+						"finished_at").
+					Values(
+						uuid.NewV4(),
+						tc.queue,
+						"test",
+						emptyJSON,
+						emptyJSON,
+						queue.Waiting,
+						task.StartedAt,
+						task.LastHeartbeatAt,
+						task.FinishedAt).
+					ExecContext(ctx)
+
+				require.NoError(t, err)
+			}
+
+			task, err := q.(*dequeuer).attemptDequeue(ctx, tc.queue)
+			if tc.expTask {
+				require.NotNil(t, task)
+			} else {
+				require.Nil(t, task)
+			}
+			if tc.expError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestProcessableQueues(t *testing.T) {
+	tests := []struct {
+		name      string
+		inflight  []string
+		potential []string
+		wanted    []string
+	}{
+		{
+			name:      "empty inflight; empty potential",
+			inflight:  nil,
+			potential: nil,
+			wanted:    nil,
+		},
+		{
+			name:      "empty inflight; some potential",
+			inflight:  nil,
+			potential: []string{"a", "b"},
+			wanted:    []string{"a", "b"},
+		},
+		{
+			name:      "some inflight; empty potential",
+			inflight:  []string{"a", "b"},
+			potential: nil,
+			wanted:    nil,
+		},
+		{
+			name:      "same inflight and potential",
+			inflight:  []string{"a", "b"},
+			potential: []string{"a", "b"},
+			wanted:    nil,
+		},
+		{
+			name:      "some similar elements in inflight and potential",
+			inflight:  []string{"a", "b"},
+			potential: []string{"a", "b", "c", "d"},
+			wanted:    []string{"c", "d"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := processableQueues(tt.inflight, tt.potential)
+			require.Equal(t, tt.wanted, result)
+		})
+	}
+}
+
+func TestQueueList(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	qs := []string{
+		queueID1,
+		queueID2,
+		queueID3,
+	}
+	sort.Strings(qs)
+
+	tests := []struct {
+		name    string
+		db      string
+		queues  []string
+		where   squirrel.Sqlizer
+		expList []string
+	}{
+		{
+			name: "no queues",
+			db:   "postgres_queue_queue_list_no_queues",
+		},
+		{
+			name:    "queues; no where statement",
+			db:      "postgres_queue_queue_list_no_where_stmt",
+			queues:  qs,
+			expList: qs,
+		},
+		{
+			name:    "queues; where statement",
+			db:      "postgres_queue_queue_list_where_stmt",
+			queues:  qs,
+			where:   squirrel.Eq{"queue": qs[0]},
+			expList: []string{qs[0]},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			name, db := dbtest.GetDatabase(t)
+			defer db.Close()
+			require.NoError(t, Setup(ctx, db, nil))
+			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
+			dbListener := pq.NewListener(
+				connStr,
+				10*time.Second,
+				time.Minute,
+				func(ev pq.ListenerEventType, err error) {
+					if err != nil {
+						logrus.Error(err)
+					}
+				},
+			)
+
+			q := NewDequeuer(db, dbListener, config.Queue{
+				HeartbeatTTL:  10 * time.Second,
+				PollFrequency: 50 * time.Millisecond,
+			})
+
+			pd := q.(*dequeuer)
+
+			for _, queueName := range tt.queues {
+				_, err := pd.GetQueryBuilder().
+					Insert("tasks").
+					Columns(
+						"task_id",
+						"queue",
+						"type",
+						"spec",
+						"progress",
+						"status",
+					).
+					Values(
+						uuid.NewV4(),
+						queueName,
+						"test",
+						emptyJSON,
+						emptyJSON,
+						queue.Waiting,
+					).
+					ExecContext(ctx)
+
+				require.NoError(t, err)
+			}
+
+			qList, err := pd.generateQueueList(ctx, tt.where)
+			sort.Strings(qList)
+			require.NoError(t, err)
+			require.Equal(t, tt.expList, qList)
+		})
+	}
+}

--- a/pkg/queue/postgres/fixtures_test.go
+++ b/pkg/queue/postgres/fixtures_test.go
@@ -1,0 +1,11 @@
+package postgres
+
+import uuid "github.com/satori/go.uuid"
+
+var (
+	queueID1 = uuid.NewV4().String()
+	queueID2 = uuid.NewV4().String()
+	queueID3 = uuid.NewV4().String()
+	progress = []byte(`{"scale": 99}`)
+	spec     = []byte(`{"field": "value"}`)
+)

--- a/pkg/queue/postgres/queuer.go
+++ b/pkg/queue/postgres/queuer.go
@@ -1,0 +1,90 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/contiamo/go-base/pkg/data/managers"
+	"github.com/contiamo/go-base/pkg/queue"
+	uuid "github.com/satori/go.uuid"
+)
+
+var emptyJSON = []byte("{}")
+
+// NewQueuer creates a new postgres queue queuer
+func NewQueuer(db *sql.DB) queue.Queuer {
+	return &queuer{
+		BaseManager: managers.NewBaseManager(db, "PostgresQueuer"),
+	}
+}
+
+// NewQueuerWithMetrics creates a new postgres queue queuer with metrics enabled
+func NewQueuerWithMetrics(db *sql.DB) queue.Queuer {
+	return queue.QueuerWithMetrics(NewQueuer(db))
+}
+
+// pgQueue is a postgres backed implementation of the queue manager
+type queuer struct {
+	managers.BaseManager
+}
+
+// Enqueue implements queue.Enqueue
+//
+// `task` must contain a Queue name and task type.
+func (q *queuer) Enqueue(ctx context.Context, task queue.TaskEnqueueRequest) (err error) {
+	span, ctx := q.StartSpan(ctx, "Enqueue")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	if task.Queue == "" {
+		return queue.ErrTaskQueueNotSpecified
+	}
+
+	if task.Type == "" {
+		return queue.ErrTaskTypeNotSpecified
+	}
+
+	if task.Spec == nil {
+		task.Spec = emptyJSON
+	}
+
+	taskID := uuid.NewV4().String()
+	span.SetTag("task.queue", task.Queue)
+	span.SetTag("task.type", task.Type)
+	span.SetTag("task.spec", string(task.Spec))
+	span.SetTag("task.references", task.References)
+
+	refColumns, refValues := task.References.GetNamesAndValues()
+
+	_, err = q.GetQueryBuilder().
+		Insert("tasks").
+		Columns(
+			append(
+				refColumns,
+				"task_id",
+				"queue",
+				"type",
+				"spec",
+				"status",
+				"progress",
+			)...,
+		).
+		Values(
+			append(
+				refValues,
+				taskID,
+				task.Queue,
+				task.Type,
+				task.Spec,
+				queue.Waiting,
+				emptyJSON,
+			)...,
+		).
+		ExecContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/queue/postgres/queuer_test.go
+++ b/pkg/queue/postgres/queuer_test.go
@@ -23,7 +23,7 @@ func TestEnqueue(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, db, nil))
+	require.NoError(t, Setup(ctx, "test", db, nil))
 	_, err := db.ExecContext(ctx, `ALTER TABLE tasks ADD column test_id uuid;`)
 	require.NoError(t, err)
 

--- a/pkg/queue/postgres/queuer_test.go
+++ b/pkg/queue/postgres/queuer_test.go
@@ -1,0 +1,119 @@
+package postgres
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	dbtest "github.com/contiamo/go-base/pkg/db/test"
+	"github.com/contiamo/go-base/pkg/queue"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnqueue(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, Setup(ctx, db, nil))
+	_, err := db.ExecContext(ctx, `ALTER TABLE tasks ADD column test_id uuid;`)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		task     queue.TaskEnqueueRequest
+		expError string
+	}{
+		{
+			name:     "Returns an error when the queue name is empty",
+			task:     queue.TaskEnqueueRequest{TaskBase: queue.TaskBase{Type: "test"}},
+			expError: queue.ErrTaskQueueNotSpecified.Error(),
+		},
+		{
+			name:     "Returns an error when the task type is empty",
+			task:     queue.TaskEnqueueRequest{TaskBase: queue.TaskBase{Queue: queueID1}},
+			expError: queue.ErrTaskTypeNotSpecified.Error(),
+		},
+
+		{
+			name: "Returns an error when the spec is not valid JSON",
+			task: queue.TaskEnqueueRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue1",
+					Type:  "test",
+					Spec:  []byte("invalid"),
+				},
+			},
+			expError: "pq: invalid input syntax for type json",
+		},
+		{
+			name: "Returns no error when a task is valid",
+			task: queue.TaskEnqueueRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+			},
+		},
+		{
+			name: "Returns no error when a task has no spec",
+			task: queue.TaskEnqueueRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+				},
+			},
+		},
+		{
+			name: "Returns no error when a task has references",
+			task: queue.TaskEnqueueRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+				References: queue.References{
+					"test_id": uuid.NewV4(),
+				},
+			},
+		},
+		{
+			name: "Returns error when a task has invalid references",
+			task: queue.TaskEnqueueRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+				References: queue.References{
+					"invalid": uuid.NewV4(),
+				},
+			},
+			expError: `pq: column "invalid" of relation "tasks" does not exist`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := NewQueuer(db)
+			err := q.Enqueue(ctx, tc.task)
+
+			if tc.expError != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.expError, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/queue/postgres/scheduler.go
+++ b/pkg/queue/postgres/scheduler.go
@@ -1,0 +1,144 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	cdb "github.com/contiamo/go-base/pkg/db"
+	"github.com/contiamo/go-base/pkg/tracing"
+	cvalidation "github.com/contiamo/go-base/pkg/validation"
+	"github.com/contiamo/go-base/pkg/queue"
+	uuid "github.com/satori/go.uuid"
+)
+
+// NewScheduler creates a new postgres task scheduler
+func NewScheduler(db *sql.DB) queue.Scheduler {
+	return &scheduler{
+		Tracer: tracing.NewTracer("queue", "PostgresScheduler"),
+	}
+}
+
+// NewScheduler creates a new postgres task scheduler with metrics enabled
+func NewSchedulerWithMetrics(db *sql.DB) queue.Scheduler {
+	return queue.SchedulerWithMetrics(NewScheduler(db))
+}
+
+// scheduler is a postgres backed implementation of the task scheduler
+type scheduler struct {
+	tracing.Tracer
+}
+
+func (q *scheduler) Schedule(ctx context.Context, builder cdb.SQLBuilder, task queue.TaskScheduleRequest) (err error) {
+	span, ctx := q.StartSpan(ctx, "Schedule")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	if task.Queue == "" {
+		return queue.ErrTaskQueueNotSpecified
+	}
+
+	if task.Type == "" {
+		return queue.ErrTaskTypeNotSpecified
+	}
+
+	if task.Spec == nil {
+		task.Spec = emptyJSON
+	}
+
+	err = cvalidation.CronTab(task.CronSchedule)
+	if err != nil {
+		return err
+	}
+
+	scheduleID := uuid.NewV4().String()
+
+	span.SetTag("schedule.id", scheduleID)
+	span.SetTag("schedule.cron", task.CronSchedule)
+	span.SetTag("schedule.references", task.References)
+	span.SetTag("task.queue", task.Queue)
+	span.SetTag("task.type", task.Type)
+	span.SetTag("task.spec", string(task.Spec))
+
+	refColumns, refValues := task.References.GetNamesAndValues()
+
+	_, err = builder.
+		Insert("schedules").
+		Columns(
+			append(
+				refColumns,
+				"schedule_id",
+				"task_queue",
+				"task_type",
+				"task_spec",
+				"cron_schedule",
+				"next_execution_time",
+			)...,
+		).
+		Values(
+			append(
+				refValues,
+				scheduleID,
+				task.Queue,
+				task.Type,
+				task.Spec,
+				task.CronSchedule,
+				time.Now(), // the schedule will enqueue the task immediately
+			)...,
+		).
+		ExecContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (q *scheduler) EnsureSchedule(ctx context.Context, builder cdb.SQLBuilder, task queue.TaskScheduleRequest) (err error) {
+	span, ctx := q.StartSpan(ctx, "EnsureSchedule")
+	defer func() {
+		q.FinishSpan(span, err)
+	}()
+
+	if task.Queue == "" {
+		return queue.ErrTaskQueueNotSpecified
+	}
+
+	if task.Type == "" {
+		return queue.ErrTaskTypeNotSpecified
+	}
+
+	span.SetTag("schedule.references", task.References)
+	span.SetTag("task.queue", task.Queue)
+	span.SetTag("task.type", task.Type)
+
+	refColumns, refValues := task.References.GetNamesAndValues()
+
+	query := builder.
+		Select("1").
+		From("schedules").
+		Limit(1).
+		Where(squirrel.Eq{"task_queue": task.Queue}).
+		Where(squirrel.Eq{"task_type": task.Type}).
+		Where(squirrel.Eq{"task_spec": []byte(task.Spec)})
+
+	for idx, col := range refColumns {
+		query = query.Where(squirrel.Eq{col: refValues[idx]})
+	}
+
+	var exists int
+	err = query.ScanContext(ctx, &exists)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+
+	// will only non-zero if err is nil
+	if exists != 0 {
+		return nil
+	}
+
+	// either value was 0 or err == sql.ErrorNoRows
+	return queue.ErrNotScheduled
+}

--- a/pkg/queue/postgres/scheduler_test.go
+++ b/pkg/queue/postgres/scheduler_test.go
@@ -1,0 +1,273 @@
+package postgres
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	dbtest "github.com/contiamo/go-base/pkg/db/test"
+	"github.com/contiamo/go-base/pkg/queue"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedule(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, Setup(ctx, db, nil))
+	_, err := db.ExecContext(ctx, `ALTER TABLE schedules ADD column test_id uuid;`)
+	require.NoError(t, err)
+
+	builder := squirrel.StatementBuilder.
+		PlaceholderFormat(squirrel.Dollar).
+		RunWith(db)
+
+	cases := []struct {
+		name     string
+		task     queue.TaskScheduleRequest
+		expError string
+	}{
+		{
+			name: "Returns an error when the queue name is empty",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Type: "test",
+					Spec: spec,
+				},
+				CronSchedule: "@weekly",
+			},
+			expError: queue.ErrTaskQueueNotSpecified.Error(),
+		},
+		{
+			name: "Returns an error when the task type is empty",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: queueID1,
+					Spec:  spec,
+				},
+				CronSchedule: "@weekly",
+			},
+			expError: queue.ErrTaskTypeNotSpecified.Error(),
+		},
+		{
+			name: "Returns an error when the spec is not valid JSON",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue1",
+					Type:  "test",
+					Spec:  []byte("invalid"),
+				},
+				CronSchedule: "@weekly",
+			},
+			expError: "pq: invalid input syntax for type json",
+		},
+		{
+			name: "Returns no error when a schedule is valid",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+				CronSchedule: "@weekly",
+			},
+		},
+		{
+			name: "Returns error when a cron schedule is not valid",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+				CronSchedule: "invalid",
+			},
+			expError: "failed to parse crontab: Expected exactly 5 fields, found 1: invalid",
+		},
+
+		{
+			name: "Returns no error when a task has no spec",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+				},
+				CronSchedule: "@weekly",
+			},
+		},
+		{
+			name: "Returns no error when a task has references",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+				CronSchedule: "@weekly",
+				References: queue.References{
+					"test_id": uuid.NewV4(),
+				},
+			},
+		},
+		{
+			name: "Returns error when a task has invalid references",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+				CronSchedule: "@weekly",
+				References: queue.References{
+					"invalid": uuid.NewV4(),
+				},
+			},
+			expError: `pq: column "invalid" of relation "schedules" does not exist`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := NewScheduler(db)
+			err := q.Schedule(ctx, builder, tc.task)
+
+			if tc.expError != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.expError, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestEnsure(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, Setup(ctx, db, nil))
+	_, err := db.ExecContext(ctx, `ALTER TABLE schedules ADD column test_id uuid;`)
+	require.NoError(t, err)
+
+	task := queue.TaskScheduleRequest{
+		TaskBase: queue.TaskBase{
+			Queue: "queue2",
+			Type:  "test",
+			Spec:  spec,
+		},
+		CronSchedule: "@weekly",
+		References: queue.References{
+			"test_id": uuid.NewV4(),
+		},
+	}
+	refColumns, refValues := task.References.GetNamesAndValues()
+	builder := squirrel.StatementBuilder.
+		PlaceholderFormat(squirrel.Dollar).
+		RunWith(db)
+
+	_, err = builder.
+		Insert("schedules").
+		Columns(
+			append(
+				refColumns,
+				"schedule_id",
+				"task_queue",
+				"task_type",
+				"task_spec",
+				"cron_schedule",
+				"next_execution_time",
+			)...,
+		).
+		Values(
+			append(
+				refValues,
+				uuid.NewV4().String(),
+				task.Queue,
+				task.Type,
+				task.Spec,
+				task.CronSchedule,
+				time.Now(), // the schedule will enqueue the task immediately
+			)...,
+		).
+		ExecContext(ctx)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		task     queue.TaskScheduleRequest
+		expError string
+	}{
+		{
+			name: "Returns an error when the queue name is empty",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Type: "test",
+					Spec: spec,
+				},
+				CronSchedule: "@weekly",
+			},
+			expError: queue.ErrTaskQueueNotSpecified.Error(),
+		},
+		{
+			name: "Returns an error when the task type is empty",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: queueID1,
+					Spec:  spec,
+				},
+				CronSchedule: "@weekly",
+			},
+			expError: queue.ErrTaskTypeNotSpecified.Error(),
+		},
+		{
+			name: "Returns error when schedule can not be found",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+				CronSchedule: "@weekly",
+				References: queue.References{
+					"test_id": uuid.NewV4(),
+				},
+			},
+			expError: queue.ErrNotScheduled.Error(),
+		},
+		{
+			name: "Returns no error when schedule exists in db",
+			task: task,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := NewScheduler(db)
+			err := q.EnsureSchedule(ctx, builder, tc.task)
+
+			if tc.expError != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.expError, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/queue/postgres/scheduler_test.go
+++ b/pkg/queue/postgres/scheduler_test.go
@@ -24,7 +24,7 @@ func TestSchedule(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, db, nil))
+	require.NoError(t, Setup(ctx, "test", db, nil))
 	_, err := db.ExecContext(ctx, `ALTER TABLE schedules ADD column test_id uuid;`)
 	require.NoError(t, err)
 
@@ -161,7 +161,7 @@ func TestEnsure(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, db, nil))
+	require.NoError(t, Setup(ctx, "test", db, nil))
 	_, err := db.ExecContext(ctx, `ALTER TABLE schedules ADD column test_id uuid;`)
 	require.NoError(t, err)
 

--- a/pkg/queue/postgres/setup.go
+++ b/pkg/queue/postgres/setup.go
@@ -1,0 +1,102 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"text/template"
+
+	"github.com/contiamo/go-base/pkg/db"
+)
+
+type ForeignReference struct {
+	ColumnName       string
+	ColumnType       string
+	ReferencedTable  string
+	ReferencedColumn string
+}
+
+func Setup(ctx context.Context, db db.SQLDB, references []ForeignReference) error {
+	buf := &bytes.Buffer{}
+	err := dbSetupTemplate.Execute(buf, references)
+	if err != nil {
+		return err
+	}
+	_, err = db.ExecContext(ctx, buf.String())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var dbSetupTemplate = template.Must(template.New("queue-db-setup").Parse(`
+CREATE EXTENSION IF NOT EXISTS citext;
+
+CREATE TABLE IF NOT EXISTS schedules (
+      schedule_id uuid PRIMARY KEY,
+    task_queue citext NOT NULL,
+    task_type citext NOT NULL,
+    task_spec jsonb NOT NULL,
+    cron_schedule citext NOT NULL DEFAULT '',
+    next_execution_time timestamptz,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    updated_at timestamptz NOT NULL DEFAULT NOW()--,
+    -- Additional columns for tasks used for clean up
+    {{ range . }}
+    ,{{ .ColumnName }} {{ .ColumnType }} REFERENCES {{ .ReferencedTable }} ({{ .ReferencedColumn}}) ON DELETE CASCADE
+    {{ end }}
+);
+CREATE INDEX IF NOT EXISTS schedule_next_execution_time_idx ON schedules (next_execution_time);
+CREATE INDEX IF NOT EXISTS schedule_task_type_idx ON schedules (task_type);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id uuid PRIMARY KEY,
+    queue citext NOT NULL,
+    TYPE citext NOT NULL,
+    spec jsonb NOT NULL,
+    status citext NOT NULL,
+    progress jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    updated_at timestamptz NOT NULL DEFAULT NOW(),
+    started_at timestamptz,
+    finished_at timestamptz,
+    last_heartbeat_at timestamptz,
+    -- Additional columns for tasks used for clean up
+    schedule_id uuid REFERENCES schedules ON DELETE CASCADE
+    {{ range . }}
+    ,{{ .ColumnName }} {{ .ColumnType }} REFERENCES {{ .ReferencedTable }} ({{ .ReferencedColumn}}) ON DELETE CASCADE
+    {{ end }}
+);
+
+CREATE INDEX IF NOT EXISTS tasks_queue_idx ON tasks (queue);
+CREATE INDEX IF NOT EXISTS tasks_type_idx ON tasks USING hash (type);
+CREATE INDEX IF NOT EXISTS tasks_created_heartbeat_at_idx ON tasks (created_at, last_heartbeat_at);
+CREATE INDEX IF NOT EXISTS tasks_created_desc_heartbeat_at_desc_idx ON tasks (created_at DESC, last_heartbeat_at DESC);
+CREATE INDEX IF NOT EXISTS tasks_created_desc_idx ON tasks (created_at DESC);
+CREATE INDEX IF NOT EXISTS tasks_last_heartbeat_at_desc_idx ON tasks (last_heartbeat_at DESC);
+CREATE INDEX IF NOT EXISTS tasks_created_updated_desc_idx ON tasks (created_at DESC, updated_at DESC);
+CREATE INDEX IF NOT EXISTS tasks_started_at_idx ON tasks (started_at)
+WHERE
+  started_at IS NULL;
+CREATE INDEX IF NOT EXISTS tasks_completed_at_idx ON tasks (finished_at)
+  WHERE
+  finished_at IS NULL;
+
+-- notify on channel 'task_update' on changes on the tasks table
+CREATE OR REPLACE FUNCTION notify_task_update ()
+    RETURNS TRIGGER
+    AS $$
+BEGIN
+    PERFORM
+        pg_notify('task_update', '');
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS notify_task_update_trigger ON tasks;
+
+CREATE TRIGGER notify_task_update_trigger
+    AFTER INSERT ON tasks
+    FOR EACH ROW
+    EXECUTE PROCEDURE notify_task_update ();
+`))

--- a/pkg/queue/postgres/setup.go
+++ b/pkg/queue/postgres/setup.go
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS schedules (
 CREATE TABLE IF NOT EXISTS tasks (
     task_id uuid PRIMARY KEY,
     queue citext NOT NULL,
-    TYPE citext NOT NULL,
+    type citext NOT NULL,
     spec jsonb NOT NULL,
     status citext NOT NULL,
     progress jsonb NOT NULL,

--- a/pkg/queue/postgres/setup.go
+++ b/pkg/queue/postgres/setup.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/contiamo/go-base/pkg/db"
+	"github.com/contiamo/go-base/pkg/queue"
 )
 
 type ForeignReference struct {
@@ -15,7 +16,12 @@ type ForeignReference struct {
 	ReferencedColumn string
 }
 
-func Setup(ctx context.Context, db db.SQLDB, references []ForeignReference) error {
+func Setup(ctx context.Context, metricsNamespace string, db db.SQLDB, references []ForeignReference) error {
+	// setup metrics
+	queue.SetupTaskQueueMetrics(metricsNamespace)
+	queue.SetupSchedulerMetrics(metricsNamespace)
+
+	// setup database
 	buf := &bytes.Buffer{}
 	err := dbSetupTemplate.Execute(buf, references)
 	if err != nil {
@@ -25,6 +31,7 @@ func Setup(ctx context.Context, db db.SQLDB, references []ForeignReference) erro
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/queue/postgres/setup_test.go
+++ b/pkg/queue/postgres/setup_test.go
@@ -1,0 +1,73 @@
+package postgres
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	dbtest "github.com/contiamo/go-base/pkg/db/test"
+	"github.com/contiamo/go-base/pkg/queue"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupWithoutReferences(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, Setup(ctx, "test", db, nil))
+}
+
+func TestStupWithReferences(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, db := dbtest.GetDatabase(t)
+	defer db.Close()
+
+	_, err := db.ExecContext(ctx, "CREATE TABLE some_entity(id UUID PRIMARY KEY);")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO some_entity(id) values('27195537-cc37-40db-acdb-424d448ec805');")
+	require.NoError(t, err)
+
+	// setup with foreign reference
+	err = Setup(ctx, "test", db, []ForeignReference{
+		{
+			ColumnName:       "entity_id",
+			ColumnType:       "UUID",
+			ReferencedTable:  "some_entity",
+			ReferencedColumn: "id",
+		},
+	})
+	require.NoError(t, err)
+
+	// create a task on the queue using this reference
+	queuer := NewQueuer(db)
+	err = queuer.Enqueue(ctx, queue.TaskEnqueueRequest{
+		TaskBase: queue.TaskBase{
+			Queue: "test-queue",
+			Type:  queue.TaskType("test-task-type"),
+			Spec:  queue.Spec("{}"),
+		},
+		References: queue.References{
+			"entity_id": "27195537-cc37-40db-acdb-424d448ec805",
+		},
+	})
+	require.NoError(t, err)
+	dbtest.EqualCount(t, db, 1, "tasks", nil)
+
+	// delete the entity, and see how the task disappears
+	_, err = db.ExecContext(ctx, "DELETE FROM some_entity;")
+	require.NoError(t, err)
+	dbtest.EqualCount(t, db, 0, "tasks", nil)
+}

--- a/pkg/queue/scheduler.go
+++ b/pkg/queue/scheduler.go
@@ -1,0 +1,50 @@
+package queue
+
+import (
+	"context"
+	"errors"
+
+	cdb "github.com/contiamo/go-base/pkg/db"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ErrNoteSchedule indicates the current scheduled task is has not been created yet. This should
+// be returned from the EnsureSchedule method
+var ErrNotScheduled = errors.New("Task not currently scheduled")
+
+// Scheduler defines how one schedules a task
+type Scheduler interface {
+	// Schedule creates a cron schedule according to which the worker will enqueue
+	// the given task.
+	// `task.CronSchedule` cannot be blank.
+	Schedule(ctx context.Context, builder cdb.SQLBuilder, task TaskScheduleRequest) error
+
+	// EnsureSchedule checks if a task for with the given queue, type, and references
+	// currently exists. An error ErrNotScheduled is returned if a current task cannot be found.
+	// implementation and validation errors may also be returned and should be checked for.
+	EnsureSchedule(ctx context.Context, builder cdb.SQLBuilder, task TaskScheduleRequest) (err error)
+}
+
+type schedulerWithMetrics struct {
+	s Scheduler
+}
+
+// SchedulerWithMetrics returns q wrapped with the standard metrics implementation
+func SchedulerWithMetrics(s Scheduler) Scheduler {
+	return &schedulerWithMetrics{s}
+}
+
+func (s *schedulerWithMetrics) Schedule(ctx context.Context, builder cdb.SQLBuilder, task TaskScheduleRequest) (err error) {
+	labels := prometheus.Labels{"queue": task.Queue, "type": task.Type.String()}
+	SchedulerMetrics.ScheduleCounter.With(labels).Inc()
+	defer func() {
+		if err != nil {
+			SchedulerMetrics.ErrorCounter.With(labels).Inc()
+		}
+	}()
+	return s.s.Schedule(ctx, builder, task)
+}
+
+func (s *schedulerWithMetrics) EnsureSchedule(ctx context.Context, builder cdb.SQLBuilder, task TaskScheduleRequest) error {
+	return s.s.EnsureSchedule(ctx, builder, task)
+}

--- a/pkg/queue/scheduler_test.go
+++ b/pkg/queue/scheduler_test.go
@@ -1,0 +1,52 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestSchedulerMetrics(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rawScheduler := SchedulerMock{}
+	s := SchedulerWithMetrics(&rawScheduler)
+
+	testTask := TaskScheduleRequest{TaskBase: TaskBase{Queue: "testQueue", Type: "tester"}, CronSchedule: "@daily"}
+	promLabels := prometheus.Labels{"queue": testTask.Queue, "type": testTask.Type.String()}
+
+	t.Run("task and error count starts at 0", func(t *testing.T) {
+		require.Equal(t, float64(0), testutil.ToFloat64(SchedulerMetrics.ScheduleCounter.With(promLabels)))
+		require.Equal(t, float64(0), testutil.ToFloat64(SchedulerMetrics.ErrorCounter.With(promLabels)))
+	})
+
+	t.Run("schedule count inc after scheduling a task", func(t *testing.T) {
+		err := s.Schedule(ctx, nil, testTask)
+		require.NoError(t, err)
+		// compairing with the rawQ count ensures that the underlying queue was called by our wrapping method
+		time.Sleep(time.Millisecond)
+		require.Equal(t, 1, rawScheduler.ScheduleCount)
+		require.Equal(t, float64(rawScheduler.ScheduleCount), testutil.ToFloat64(SchedulerMetrics.ScheduleCounter.With(promLabels)))
+		require.Equal(t, float64(0), testutil.ToFloat64(SchedulerMetrics.ErrorCounter.With(promLabels)))
+	})
+
+	t.Run("schedule count inc after scheduling a task", func(t *testing.T) {
+		rawScheduler.ScheduleErr = errors.New("scheduler oops")
+		err := s.Schedule(ctx, nil, testTask)
+		require.EqualError(t, err, "scheduler oops")
+
+		// compairing with the rawQ count ensures that the underlying queue was called by our wrapping method
+		time.Sleep(time.Millisecond)
+		require.Equal(t, 2, rawScheduler.ScheduleCount)
+		require.Equal(t, float64(rawScheduler.ScheduleCount), testutil.ToFloat64(SchedulerMetrics.ScheduleCounter.With(promLabels)))
+		require.Equal(t, float64(1), testutil.ToFloat64(SchedulerMetrics.ErrorCounter.With(promLabels)))
+	})
+}

--- a/pkg/queue/task.go
+++ b/pkg/queue/task.go
@@ -1,0 +1,111 @@
+package queue
+
+import "time"
+
+// References is a dictionary of additinal SQL columns to set.
+// Normally this dictionary contains referencies to other entities
+// e.g. datasource_id, table_id, schedule_id, etc.
+// So, the SQL table can have the `DELETE CASCADE` setting.
+type References map[string]interface{}
+
+// GetNamesAndValues returns a slice of column names and a slice of values accordingly.
+// It's to easily use it in the SQL builder.
+func (a References) GetNamesAndValues() (keys []string, values []interface{}) {
+	if a == nil {
+		return keys, values
+	}
+	l := len(a)
+	keys, values = make([]string, 0, l), make([]interface{}, 0, l)
+	for k, v := range a {
+		keys = append(keys, k)
+		values = append(values, v)
+	}
+
+	return keys, values
+}
+
+// Progress is a serialized status object that indicates the status of the task
+// For example, it can be an object that contains the amount of processed bytes.
+// The actual underlying type depends on the task type and consumers must serialize the value.
+type Progress []byte
+
+// Spec is is a serialized specification object used to set the task parameters.
+// The actual underlying type depends on the task type and consumers must serialize the value.
+type Spec []byte
+
+// TaskType is a type which specifies what a task it is
+type TaskType string
+
+// String returns a string value of the task type
+func (t TaskType) String() string {
+	return string(t)
+}
+
+// TaskStatus : Current state of the task
+type TaskStatus string
+
+// List of TaskStatus
+const (
+	// Waiting task is waiting for being picked up
+	Waiting TaskStatus = "waiting"
+	// Running task is currently running
+	Running TaskStatus = "running"
+	// Cancelled task is cancelled by the user
+	Cancelled TaskStatus = "cancelled"
+	// Finished task is successfully finished
+	Finished TaskStatus = "finished"
+	// Failed task is failed with an error
+	Failed TaskStatus = "failed"
+)
+
+// TaskBase contains basic fields for a task
+type TaskBase struct {
+	// Queue is the queue to which the task belongs
+	Queue string
+	// Type holds a task type identifier
+	Type TaskType
+	// Spec contains the task specification based on type of the task.
+	Spec Spec
+}
+
+// TaskEnqueueRequest contains fields required for adding a task to the queue
+type TaskEnqueueRequest struct {
+	TaskBase
+	// References contain names and values for additinal
+	// SQL columns to set external references for a task for easy clean up
+	References References
+}
+
+// TaskScheduleRequest contains fields required for scheduling a task
+type TaskScheduleRequest struct {
+	TaskBase
+	// CronSchedule is the schedule impression in cron syntax that defines
+	// when the task should be executed.
+	CronSchedule string
+	// References contain names and values for additinal
+	// SQL columns to set external references for a schedule for easy clean up
+	References References
+}
+
+// Task represents a task in the queue
+type Task struct {
+	TaskBase
+	// ID is the id of the task
+	ID string
+	// Status is the current status of the task
+	Status TaskStatus
+	// Progress is used for workers to update the status of the task.
+	// For example, bytes processed.
+	// The actual underlying type is specific for each task type.
+	Progress Progress
+	// CreatedAt is when the task was initially put in the queue
+	CreatedAt time.Time
+	// CreatedAt is when the task was initially put in the queue
+	UpdatedAt time.Time
+	// StartedAt is when a worker picked up the task
+	StartedAt *time.Time
+	// FinishedAt is when the task was finished being processed
+	FinishedAt *time.Time
+	// LastHeartbeat provides a way to ensure the task is still being processed and hasn't failed.
+	LastHeartbeatAt *time.Time
+}

--- a/pkg/queue/workers/metrics.go
+++ b/pkg/queue/workers/metrics.go
@@ -1,0 +1,174 @@
+package workers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// largest bucket is 83 min
+var (
+	durationSBuckets  = []float64{1, 10, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000}
+	durationMsBuckets = []float64{10, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000}
+	queueMetricLabels = []string{"queue"}
+	taskMetricLabels  = []string{"queue", "type"}
+)
+
+// TaskQueueMetrics provides access to the prometheus metric objects for the task queue
+var TaskQueueMetrics = struct {
+	Labels             []string
+	TaskDuration       *prometheus.HistogramVec
+	TaskWaiting        *prometheus.HistogramVec
+	DequeueDuration    prometheus.Histogram
+	WorkerGauge        prometheus.Gauge
+	WorkerWaiting      prometheus.Counter
+	WorkerWorking      *prometheus.CounterVec
+	WorkerWorkingGauge *prometheus.GaugeVec
+	WorkerTask         *prometheus.CounterVec
+	WorkerErrors       *prometheus.CounterVec
+	QueueErrors        prometheus.Counter
+}{
+	Labels: queueMetricLabels,
+	TaskDuration: promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "hub",
+			Subsystem: "worker",
+			Name:      "duration_s",
+			Help:      "duration of a task in seconds by queue",
+			Buckets:   durationSBuckets,
+		},
+		taskMetricLabels,
+	),
+	TaskWaiting: promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "hub",
+			Subsystem: "queue",
+			Name:      "waiting_duration_s",
+			Help:      "duration of a task waiting to start",
+			Buckets:   durationSBuckets,
+		},
+		taskMetricLabels,
+	),
+	DequeueDuration: promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "hub",
+			Subsystem: "worker",
+			Name:      "wait_duration_s",
+			Help:      "duration in seconds a worker spent waiting",
+			Buckets:   durationSBuckets,
+		},
+	),
+	WorkerGauge: promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "hub",
+		Subsystem: "worker",
+		Name:      "count",
+		Help:      "count of initialized workers",
+	}),
+	WorkerWaiting: promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "hub",
+		Subsystem: "worker",
+		Name:      "waiting_count",
+		Help:      "count of workers waiting for a task",
+	}),
+	WorkerWorking: promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hub",
+			Subsystem: "worker",
+			Name:      "working_total",
+			Help:      "count of workers working on a task",
+		},
+		taskMetricLabels,
+	),
+	WorkerWorkingGauge: promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "hub",
+			Subsystem: "worker",
+			Name:      "working",
+			Help:      "count of working workers",
+		},
+		taskMetricLabels,
+	),
+	WorkerTask: promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hub",
+			Subsystem: "worker",
+			Name:      "task_total",
+			Help:      "count of tasks seen by the worker",
+		},
+		taskMetricLabels,
+	),
+	WorkerErrors: promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hub",
+			Subsystem: "worker",
+			Name:      "error_total",
+			Help:      "count of errors seen by the worker",
+		},
+		taskMetricLabels,
+	),
+	QueueErrors: promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "hub",
+		Subsystem: "worker",
+		Name:      "queue_error_total",
+		Help:      "count of dequeue errors seen by the worker",
+	}),
+}
+
+// TaskSchedulingMetrics provides access to the prometheus metric objects for task scheduling
+var TaskSchedulingMetrics = struct {
+	Labels            []string
+	IterationDuration prometheus.Histogram
+	WorkerGauge,
+	WorkerWorkingGauge prometheus.Gauge
+	WorkerWaiting,
+	WorkerWorking,
+	WorkerErrors prometheus.Counter
+	WorkerTaskScheduled *prometheus.CounterVec
+}{
+	Labels: queueMetricLabels,
+	IterationDuration: promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "hub",
+		Subsystem: "scheduling",
+		Name:      "iteration_duration_ms",
+		Help:      "duration of the scheduling iteration in ms",
+		Buckets:   durationMsBuckets,
+	}),
+	WorkerGauge: promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "hub",
+		Subsystem: "scheduling",
+		Name:      "count",
+		Help:      "count of initialized task scheduling workers",
+	}),
+	WorkerWorkingGauge: promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "hub",
+		Subsystem: "scheduling",
+		Name:      "working_count",
+		Help:      "count of working task scheduling workers",
+	}),
+	WorkerWaiting: promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "hub",
+		Subsystem: "scheduling",
+		Name:      "waiting_total",
+		Help:      "count of workers waiting for a task to schedule",
+	}),
+	WorkerWorking: promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "hub",
+		Subsystem: "scheduling",
+		Name:      "working_total",
+		Help:      "count of workers working on a task scheduling",
+	}),
+	WorkerErrors: promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "hub",
+		Subsystem: "scheduling",
+		Name:      "error_total",
+		Help:      "count of task scheduling errors seen by the worker",
+	}),
+	WorkerTaskScheduled: promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hub",
+			Subsystem: "scheduling",
+			Name:      "task_total",
+			Help:      "count of tasks scheduled by the worker",
+		},
+		taskMetricLabels,
+	),
+}

--- a/pkg/queue/workers/schedule_worker.go
+++ b/pkg/queue/workers/schedule_worker.go
@@ -1,0 +1,249 @@
+package workers
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	cdb "github.com/contiamo/go-base/pkg/db"
+	"github.com/contiamo/go-base/pkg/tracing"
+	cvalidation "github.com/contiamo/go-base/pkg/validation"
+	"github.com/contiamo/go-base/pkg/queue"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/robfig/cron"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// ErrScheduleQueueIsEmpty occurs when there is no schedule with
+	// the `next_execution_time` in the past
+	ErrScheduleQueueIsEmpty = errors.New("nothing to schedule")
+)
+
+// NewScheduleWorker creates a new task scheduling worker
+func NewScheduleWorker(db *sql.DB, queue queue.Queuer, interval time.Duration) Worker {
+	return newScheduleWorker(db, queue, interval)
+}
+
+func newScheduleWorker(db *sql.DB, queue queue.Queuer, interval time.Duration) *scheduleWorker {
+	return &scheduleWorker{
+		Tracer:   tracing.NewTracer("workers", "ScheduleWorker"),
+		queue:    queue,
+		interval: interval,
+		db:       db,
+	}
+}
+
+type scheduleWorker struct {
+	tracing.Tracer
+	db       *sql.DB
+	queue    queue.Queuer
+	interval time.Duration
+}
+
+// Work starts an infinite loop with work iterations and waits the given
+// amount of time between iterations
+func (w *scheduleWorker) Work(ctx context.Context) (err error) {
+	tracer := opentracing.GlobalTracer()
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	TaskSchedulingMetrics.WorkerGauge.Inc()
+	defer TaskSchedulingMetrics.WorkerGauge.Dec()
+
+	// the error in the iteration should not stop the work
+	// it's logged by the Tracer interface, so we don't have to handle it here
+	// since the ticker delivers the first tick after the interval we need to run it for the
+	// first time out of the loop
+	e := w.iteration(ctx, tracer)
+	if e != nil {
+		logrus.Error(e)
+	}
+
+	logrus.Debug("starting task scheduling loop...")
+	// while ctx is not cancelled or interrupted
+	for {
+		TaskSchedulingMetrics.WorkerWaiting.Inc()
+		select {
+		case <-ctx.Done():
+			logrus.Debug("scheduling loop is interrupted")
+			return ctx.Err()
+		case <-ticker.C:
+			e := w.iteration(ctx, tracer)
+			if e != nil {
+				logrus.Error(e)
+			}
+
+		}
+	}
+}
+
+// iteration finds all the tasks that require to be scheduled as tasks and then returns
+// `nil` if there is no error while doing so
+// One iteration is dealing with multiple tasks scheduling until there is no task to
+// schedule anymore, than it makes a break until the next `w.interval` tick
+func (w *scheduleWorker) iteration(ctx context.Context, tracer opentracing.Tracer) (err error) {
+	span := tracer.StartSpan("iteration")
+	ctx, cancel := context.WithCancel(opentracing.ContextWithSpan(ctx, span))
+	defer func() {
+		cancel()
+		w.FinishSpan(span, err)
+		if err != nil {
+			TaskSchedulingMetrics.WorkerErrors.Inc()
+		}
+	}()
+
+	TaskSchedulingMetrics.WorkerWorking.Inc()
+	TaskSchedulingMetrics.WorkerWorkingGauge.Inc()
+	defer TaskSchedulingMetrics.WorkerWorkingGauge.Dec()
+	timer := prometheus.NewTimer(TaskSchedulingMetrics.IterationDuration)
+	defer timer.ObserveDuration()
+
+	logrus.Debug("starting task scheduling iteration...")
+	for {
+		// check if the iteration was cancelled
+		err = ctx.Err()
+		if err != nil {
+			logrus.Debug("task scheduling iteration is interrupted")
+			return err
+		}
+
+		logrus.Debug("trying to find a task to schedule...")
+		err = w.scheduleTask(ctx)
+		if err == ErrScheduleQueueIsEmpty {
+			logrus.Debug(err.Error())
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (w *scheduleWorker) scheduleTask(ctx context.Context) (err error) {
+	span, ctx := w.StartSpan(ctx, "scheduleTask")
+	defer func() {
+		// this not really an error that we need to log
+		// it's just to indicate the calling function to take a break
+		// before it tries again
+		if err == ErrScheduleQueueIsEmpty {
+			w.FinishSpan(span, nil)
+		} else {
+			w.FinishSpan(span, err)
+		}
+	}()
+
+	tx, err := w.db.BeginTx(ctx, nil)
+	builder := squirrel.StatementBuilder.
+		PlaceholderFormat(squirrel.Dollar).
+		RunWith(cdb.WrapWithTracing(tx))
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			err = errors.Wrap(err, rollbackErr.Error())
+		}
+	}()
+
+	var (
+		scheduleID   string
+		cronSchedule string
+		taskQueue    string
+		taskType     queue.TaskType
+		specBytes    []byte
+	)
+
+	// this will lock the schedule row until the transaction is closed
+	row := builder.
+		Select(
+			"schedule_id",
+			"task_type",
+			"task_queue",
+			"task_spec",
+			"cron_schedule",
+		).
+		From("schedules").
+		Where("next_execution_time <= Now()").
+		OrderBy("next_execution_time").
+		Limit(1).
+		// Skipping locked rows provides an inconsistent view of the data,
+		// so this is not suitable for general purpose work,
+		// but can be used to avoid lock contention with multiple consumers
+		// accessing a queue-like table.
+		// https://devdocs.io/postgresql~10/sql-select#SQL-FOR-UPDATE-SHARE
+		Suffix("FOR NO KEY UPDATE SKIP LOCKED").
+		QueryRowContext(ctx)
+
+	err = row.Scan(
+		&scheduleID,
+		&taskType,
+		&taskQueue,
+		&specBytes,
+		&cronSchedule,
+	)
+	if err == sql.ErrNoRows {
+		return ErrScheduleQueueIsEmpty
+	}
+	if err != nil {
+		return err
+	}
+
+	span.SetTag("schedule.id", scheduleID)
+	span.SetTag("schedule.cron", cronSchedule)
+	span.SetTag("task.type", taskType.String())
+	span.SetTag("task.queue", taskQueue)
+	span.SetTag("task.spec", string(specBytes))
+
+	logrus := logrus.WithField("type", taskType).WithField("queue", taskQueue)
+
+	logrus.Debug("adding the task to the queue...")
+	task := queue.TaskEnqueueRequest{
+		TaskBase: queue.TaskBase{
+			Queue: taskQueue,
+			Type:  taskType,
+			Spec:  specBytes,
+		},
+		References: queue.References{
+			"schedule_id": scheduleID,
+		},
+	}
+	err = w.queue.Enqueue(ctx, task)
+	if err != nil {
+		return err
+	}
+
+	l := prometheus.Labels{"queue": taskQueue, "type": taskType.String()}
+	TaskSchedulingMetrics.WorkerTaskScheduled.With(l).Inc()
+
+	logrus.Debug("task has been scheduled successfully")
+
+	logrus.Debug("calculating and updating the next execution time...")
+
+	var nextExecution *time.Time
+	if cronSchedule != "" {
+		p := cron.NewParser(cvalidation.JobCronFormat)
+		schedule, err := p.Parse(cronSchedule)
+		if err != nil {
+			return err
+		}
+		t := schedule.Next(time.Now())
+		nextExecution = &t
+	}
+
+	_, err = builder.
+		Update("schedules").
+		Set("next_execution_time", nextExecution).
+		Where("schedule_id=?", scheduleID).
+		ExecContext(ctx)
+	if err != nil {
+		return err
+	}
+	logrus.Debug("the new execution time is set")
+	return nil
+}

--- a/pkg/queue/workers/schedule_worker_test.go
+++ b/pkg/queue/workers/schedule_worker_test.go
@@ -1,0 +1,184 @@
+package workers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+
+	dbtest "github.com/contiamo/go-base/pkg/db/test"
+	"github.com/contiamo/go-base/pkg/queue"
+	"github.com/contiamo/go-base/pkg/queue/postgres"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestScheduleTask(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Run("Takes a schedule from the queue and enqueues tasks", func(t *testing.T) {
+		_, db := dbtest.GetDatabase(t)
+		defer db.Close()
+		require.NoError(t, postgres.Setup(ctx, db, nil))
+
+		scheduleID1 := uuid.NewV4().String()
+		scheduleID2 := uuid.NewV4().String()
+		now := time.Now().Add(-1 * time.Minute).Round(time.Second)
+		taskQueue1 := "queue1"
+		taskQueue2 := "queue2"
+		taskType := "type"
+		taskSpec1 := []byte(`{"field": "value1"}`)
+		taskSpec2 := []byte(`{"field": "value2"}`)
+
+		builder := squirrel.StatementBuilder.
+			PlaceholderFormat(squirrel.Dollar).
+			RunWith(db)
+
+		_, err := builder.
+			Insert("schedules").
+			Columns(
+				"schedule_id",
+				"task_queue",
+				"task_type",
+				"task_spec",
+				"cron_schedule",
+				"next_execution_time",
+				"created_at",
+				"updated_at",
+			).
+			Values(
+				scheduleID1,
+				taskQueue1,
+				taskType,
+				taskSpec1,
+				"@weekly",
+				now.Add(-2*time.Minute), // this must be executed instantly
+				now.Add(-1*time.Minute),
+				now.Add(-1*time.Minute),
+			).
+			Values(
+				scheduleID2,
+				taskQueue2,
+				taskType,
+				taskSpec2,
+				"",
+				now.Add(-1*time.Minute), // this must be executed after the first
+				now.Add(-1*time.Minute),
+				now.Add(-1*time.Minute),
+			).
+			ExecContext(ctx)
+		require.NoError(t, err)
+
+		qm := &queueMock{}
+		w := newScheduleWorker(db, qm, time.Second)
+		err = w.scheduleTask(ctx)
+		require.NoError(t, err)
+		err = w.scheduleTask(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, qm.q, 2)
+
+		task1 := qm.q[0]
+		require.Equal(t, taskQueue1, task1.Queue)
+		require.Equal(t, taskType, task1.Type.String())
+		require.Equal(t, string(taskSpec1), string(task1.Spec))
+
+		task2 := qm.q[1]
+		require.Equal(t, taskQueue2, task2.Queue)
+		require.Equal(t, taskType, task2.Type.String())
+		require.Equal(t, string(taskSpec2), string(task2.Spec))
+
+		// checking that the execution time has changed
+		dbtest.EqualCount(t, db, 0, "schedules", squirrel.Eq{
+			"next_execution_time": now,
+		})
+
+		// these should stay zero because they are not incremented in the scheduleTask function
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerGauge))
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWorkingGauge))
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWaiting))
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWorking))
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerErrors))
+		// this should increase because the task is scheduled
+		promLabels1 := prometheus.Labels{"queue": task1.Queue, "type": task1.Type.String()}
+		require.Equal(t, float64(1), testutil.ToFloat64(TaskSchedulingMetrics.WorkerTaskScheduled.With(promLabels1)))
+		promLabels2 := prometheus.Labels{"queue": task2.Queue, "type": task2.Type.String()}
+		require.Equal(t, float64(1), testutil.ToFloat64(TaskSchedulingMetrics.WorkerTaskScheduled.With(promLabels2)))
+	})
+
+	t.Run("Returns ErrScheduleQueueIsEmpty if there is no task to schedule", func(t *testing.T) {
+		_, db := dbtest.GetDatabase(t)
+		defer db.Close()
+		require.NoError(t, postgres.Setup(ctx, db, nil))
+
+		qm := &queueMock{}
+		w := newScheduleWorker(db, qm, time.Second)
+		err := w.scheduleTask(ctx)
+		require.Error(t, err)
+		require.Equal(t, ErrScheduleQueueIsEmpty, err)
+		require.Len(t, qm.q, 0)
+	})
+}
+
+func TestMetrics(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// these should be zero in the beginning of the test
+	require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerGauge))
+	require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWorkingGauge))
+	require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWaiting))
+	require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWorking))
+
+	_, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, postgres.Setup(context.TODO(), db, nil))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// the interval must be greater than the context cancellation time
+	w := newScheduleWorker(db, &queueMock{}, 750*time.Millisecond)
+	go func() {
+		_ = w.Work(ctx)
+	}()
+	<-ctx.Done()
+	<-time.After(100 * time.Millisecond) // let the work to shutdown
+
+	// these gauges should get back to zero
+	require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerGauge))
+	require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWorkingGauge))
+	// because context interruption is an error
+	require.Equal(t, float64(0), testutil.ToFloat64(TaskSchedulingMetrics.WorkerErrors))
+	// these counters should increase
+	// the first iteration has time to succeed, the second waiting is interrupted
+	require.Equal(t, float64(2), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWaiting))
+	// the first iteration starts immediately and the second after the interval tick
+	require.Equal(t, float64(2), testutil.ToFloat64(TaskSchedulingMetrics.WorkerWorking))
+}
+
+type queueMock struct {
+	enqueue error
+	q       []queue.TaskEnqueueRequest
+}
+
+func (q *queueMock) Enqueue(ctx context.Context, task queue.TaskEnqueueRequest) error {
+	q.q = append(q.q, task)
+	return q.enqueue
+}
+
+func (q *queueMock) Dequeue(ctx context.Context, queue ...string) (*queue.Task, error) {
+	return nil, nil
+}
+
+func (q *queueMock) Heartbeat(ctx context.Context, taskID string, progress queue.Progress) error {
+	return nil
+}
+
+func (q *queueMock) Finish(ctx context.Context, taskID string, progress queue.Progress) error {
+	return nil
+}

--- a/pkg/queue/workers/schedule_worker_test.go
+++ b/pkg/queue/workers/schedule_worker_test.go
@@ -24,7 +24,7 @@ func TestScheduleTask(t *testing.T) {
 	t.Run("Takes a schedule from the queue and enqueues tasks", func(t *testing.T) {
 		_, db := dbtest.GetDatabase(t)
 		defer db.Close()
-		require.NoError(t, postgres.Setup(ctx, db, nil))
+		require.NoError(t, postgres.Setup(ctx, "test", db, nil))
 
 		scheduleID1 := uuid.NewV4().String()
 		scheduleID2 := uuid.NewV4().String()
@@ -114,7 +114,7 @@ func TestScheduleTask(t *testing.T) {
 	t.Run("Returns ErrScheduleQueueIsEmpty if there is no task to schedule", func(t *testing.T) {
 		_, db := dbtest.GetDatabase(t)
 		defer db.Close()
-		require.NoError(t, postgres.Setup(ctx, db, nil))
+		require.NoError(t, postgres.Setup(ctx, "test", db, nil))
 
 		qm := &queueMock{}
 		w := newScheduleWorker(db, qm, time.Second)
@@ -136,7 +136,7 @@ func TestMetrics(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, postgres.Setup(context.TODO(), db, nil))
+	require.NoError(t, postgres.Setup(context.TODO(), "test", db, nil))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()

--- a/pkg/queue/workers/task_worker.go
+++ b/pkg/queue/workers/task_worker.go
@@ -1,0 +1,204 @@
+package workers
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/contiamo/go-base/pkg/queue"
+
+	"github.com/contiamo/go-base/pkg/tracing"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// TaskHandler is a type alias for a method that parses a task and returns any processing errors
+type TaskHandler interface {
+	// Process implements the specific Task parsing logic
+	Process(ctx context.Context, task queue.Task, heartbeats chan<- queue.Progress) (err error)
+}
+
+// TaskHandlerFunc is an adapter that allows the use of a normal function
+// as a TaskHandler
+type TaskHandlerFunc func(context.Context, queue.Task, chan<- queue.Progress) error
+
+// Process implements the specific Task parsing logic
+func (f TaskHandlerFunc) Process(ctx context.Context, task queue.Task, heartbeats chan<- queue.Progress) error {
+	return f(ctx, task, heartbeats)
+}
+
+type queueEvent struct {
+	task *queue.Task
+	err  error
+}
+
+// NewTaskWorker creates a new Task Worker instance
+func NewTaskWorker(dequeuer queue.Dequeuer, handler TaskHandler) Worker {
+	return &taskWorker{
+		Tracer:   tracing.NewTracer("workers", "TaskWorker"),
+		dequeuer: dequeuer,
+		handler:  handler,
+		maxWait:  1 * time.Minute,
+	}
+}
+
+type taskWorker struct {
+	tracing.Tracer
+
+	handler  TaskHandler
+	dequeuer queue.Dequeuer
+	maxWait  time.Duration
+
+	Worker
+}
+
+func (w *taskWorker) iteration(ctx context.Context, tracer opentracing.Tracer, ticker *time.Ticker) (err error) {
+	logrus.Debug("starting work attempt")
+
+	span := tracer.StartSpan("iteration")
+	ctx, cancel := context.WithCancel(opentracing.ContextWithSpan(ctx, span))
+	defer func() {
+		// stop any ongoing dequeue attempt or work
+		cancel()
+		w.FinishSpan(span, err)
+	}()
+
+	events := w.startDequeue(ctx)
+	TaskQueueMetrics.WorkerWaiting.Inc()
+	logrus.Debug("waiting to dequeue a task")
+
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+		if err != nil {
+			return err
+		}
+		span.SetTag("cancelled", "true")
+		logrus.Debug("worker cancelled")
+	case <-ticker.C:
+		// set a ticker so that the tracing/logging isn't too long, otherwise
+		// we can end up with spans that are hours long
+		span.SetTag("skipped", "true")
+		logrus.Debug("work loop skipped/reset")
+		return nil
+	case event := <-events:
+		err = w.verifyQueueEvent(event)
+		if err != nil {
+			logrus.Errorf("error dequeueing task: %s", err.Error())
+			TaskQueueMetrics.QueueErrors.Inc()
+			return nil
+		}
+
+		return w.handleTask(ctx, *event.task)
+	}
+
+	return nil
+}
+
+// handleTask is responsible for actually calling the handler.Process method.  This method includes
+// the standardized logic need for metrics and handling cancellation errors
+func (w *taskWorker) handleTask(ctx context.Context, task queue.Task) (err error) {
+	span, ctx := w.StartSpan(ctx, "handleTask")
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		w.FinishSpan(span, err)
+
+	}()
+
+	log := logrus.WithField("worker", "handleTask")
+
+	l := prometheus.Labels{"queue": task.Queue, "type": task.Type.String()}
+	timer := prometheus.NewTimer(TaskQueueMetrics.TaskDuration.With(l))
+	defer timer.ObserveDuration()
+
+	TaskQueueMetrics.WorkerWorking.With(l).Inc()
+	TaskQueueMetrics.WorkerTask.With(l).Inc()
+
+	TaskQueueMetrics.WorkerWorkingGauge.With(l).Inc()
+	defer TaskQueueMetrics.WorkerWorkingGauge.With(l).Dec()
+
+	heartbeats := make(chan queue.Progress)
+	var workErr error
+	go func() {
+		// handler.Process is responsible for closing the heartbeats channel
+		// if `Process` returns an error it means the task failed
+		workErr = w.handler.Process(ctx, task, heartbeats)
+		if workErr != nil {
+			TaskQueueMetrics.WorkerErrors.With(l).Inc()
+		}
+	}()
+
+	// assumes that the handler will close the heartbeats channel when if finishes/errors
+	var progress queue.Progress
+	for progress = range heartbeats {
+		hrtErr := w.dequeuer.Heartbeat(ctx, task.ID, progress)
+		if hrtErr != nil {
+			switch hrtErr {
+			case queue.ErrTaskCancelled, queue.ErrTaskFinished, queue.ErrTaskNotFound, queue.ErrTaskNotRunning:
+				log.Error(hrtErr)
+				// finished/cancelled errors are not considered event errors, stop and return nil
+				return nil
+			default:
+				return hrtErr
+			}
+		}
+	}
+
+	if workErr != nil {
+		return w.dequeuer.Fail(ctx, task.ID, progress)
+	}
+
+	return w.dequeuer.Finish(ctx, task.ID, progress)
+}
+
+func (w *taskWorker) Work(ctx context.Context) (err error) {
+	logrus.Debug("starting task worker")
+	TaskQueueMetrics.WorkerGauge.Inc()
+	defer TaskQueueMetrics.WorkerGauge.Dec()
+
+	tracer := opentracing.GlobalTracer()
+
+	ticker := time.NewTicker(w.maxWait)
+	defer ticker.Stop()
+
+	// while ctx is not cancelled or interrupted
+	for err == nil {
+		err = w.iteration(ctx, tracer, ticker)
+	}
+
+	return err
+}
+
+// verifyQueueEvent is a helper to detect if the queue emitted an error
+func (w *taskWorker) verifyQueueEvent(event *queueEvent) error {
+	if event.err != nil {
+		return event.err
+	}
+
+	if event.task == nil {
+		return errors.New("unexpected empty task")
+	}
+	return nil
+}
+
+// dequeue wraps the Dequeue in channels to make the channel select easier
+func (w *taskWorker) startDequeue(ctx context.Context) <-chan *queueEvent {
+	queueEvents := make(chan *queueEvent, 1)
+	go func() {
+		timer := prometheus.NewTimer(TaskQueueMetrics.DequeueDuration)
+		defer timer.ObserveDuration()
+
+		t, err := w.dequeuer.Dequeue(ctx)
+
+		if t != nil {
+			l := prometheus.Labels{"queue": t.Queue, "type": t.Type.String()}
+			TaskQueueMetrics.TaskWaiting.With(l).Observe(time.Since(t.CreatedAt).Seconds())
+		}
+
+		queueEvents <- &queueEvent{task: t, err: err}
+	}()
+
+	return queueEvents
+}

--- a/pkg/queue/workers/task_worker_test.go
+++ b/pkg/queue/workers/task_worker_test.go
@@ -1,0 +1,277 @@
+package workers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/contiamo/go-base/pkg/queue"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/contiamo/go-base/pkg/http/middlewares/authorization"
+)
+
+func Test_WorkerMetrics(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	qCh := make(chan *queue.Task)
+	q := &mockQueue{queue: qCh}
+
+	handler := TaskHandlerFunc(func(ctx context.Context, task queue.Task, heartbeats chan<- queue.Progress) error {
+		defer close(heartbeats)
+
+		require.NotNil(t, task)
+		require.Equal(t, "testTask", task.ID)
+		require.Equal(t, "testQueue", task.Queue)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.NewTimer(time.Second).C:
+			// mimic a successfull processing
+			heartbeats <- queue.Progress{}
+		}
+
+		return nil
+	})
+	w := NewTaskWorker(q, handler)
+
+	t.Run("worker count starts at 0", func(t *testing.T) {
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskQueueMetrics.WorkerGauge))
+	})
+	go func() {
+		err := w.Work(ctx)
+		if err != nil {
+			logrus.Debug(err)
+		}
+	}()
+
+	metricSleep := 50 * time.Millisecond
+	time.Sleep(metricSleep)
+	testTask := &queue.Task{TaskBase: queue.TaskBase{Queue: "testQueue"}, ID: "testTask"}
+	promLabels := prometheus.Labels{"queue": testTask.Queue, "type": testTask.Type.String()}
+	t.Run("calling work inc the worker", func(t *testing.T) {
+		require.Equal(t, float64(1), testutil.ToFloat64(TaskQueueMetrics.WorkerGauge))
+		require.Equal(t, float64(1), testutil.ToFloat64(TaskQueueMetrics.WorkerWaiting))
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskQueueMetrics.WorkerWorkingGauge.With(promLabels)))
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskQueueMetrics.WorkerWorking.With(promLabels)))
+	})
+
+	qCh <- testTask
+	time.Sleep(metricSleep)
+	t.Run("active worker count inc after enqueueing a task", func(t *testing.T) {
+		require.Equal(t, float64(1), testutil.ToFloat64(TaskQueueMetrics.WorkerWorking.With(promLabels)))
+		require.Equal(t, float64(1), testutil.ToFloat64(TaskQueueMetrics.WorkerWorkingGauge.With(promLabels)))
+	})
+
+	cancel()
+	time.Sleep(metricSleep)
+	t.Run("worker count returns to 0 when worker is cancelled", func(t *testing.T) {
+		require.Equal(t, float64(0), testutil.ToFloat64(TaskQueueMetrics.WorkerGauge))
+	})
+
+}
+
+func Test_WorkerHeartbeatUnknownErrorIsReturned(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	qCh := make(chan *queue.Task, 1)
+	q := &mockQueue{queue: qCh, heartbeatErr: errors.New("can not hearbeat")}
+
+	testTask := &queue.Task{TaskBase: queue.TaskBase{Queue: "testQueue"}, ID: "testTask"}
+	qCh <- testTask
+
+	handler := TaskHandlerFunc(func(ctx context.Context, task queue.Task, heartbeats chan<- queue.Progress) error {
+		defer close(heartbeats)
+
+		require.NotNil(t, task)
+		require.Equal(t, testTask.ID, task.ID)
+		require.Equal(t, testTask.Queue, task.Queue)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.NewTimer(time.Second).C:
+			// mimic a successfull processing
+			heartbeats <- queue.Progress{}
+		}
+
+		return nil
+	})
+
+	w := NewTaskWorker(q, handler)
+	err := w.Work(ctx)
+	require.EqualError(t, err, "can not hearbeat")
+}
+
+func Test_WorkerDequeueErrorIsNotReturned(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var logs bytes.Buffer
+	logrus.SetOutput(&logs)
+
+	qCh := make(chan *queue.Task, 1)
+	q := &mockQueue{queue: qCh, dequeueErr: errors.New("can not dequeue")}
+
+	testTask := &queue.Task{TaskBase: queue.TaskBase{Queue: "testQueue"}, ID: "testTask"}
+	qCh <- testTask
+
+	handler := TaskHandlerFunc(func(ctx context.Context, task queue.Task, heartbeats chan<- queue.Progress) error {
+		defer close(heartbeats)
+
+		require.NotNil(t, task)
+		require.Equal(t, testTask.ID, task.ID)
+		require.Equal(t, testTask.Queue, task.Queue)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.NewTimer(time.Second).C:
+			// mimic a successfull processing
+			heartbeats <- queue.Progress{}
+		}
+
+		return nil
+	})
+
+	w := NewTaskWorker(q, handler)
+
+	done := make(chan error)
+	go func() {
+		done <- w.Work(ctx)
+	}()
+
+	time.Sleep(3 * time.Millisecond)
+	cancel()
+	err := <-done
+	// we should get the context error from the Work thread because the dequeue
+	// is not a fatal error, but we should see the dequeue error in the logs
+	require.EqualError(t, err, "context canceled")
+	require.Contains(t, logs.String(), "can not dequeue")
+}
+
+func Test_WorkerFindsFinishedTask(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	var logs bytes.Buffer
+	logrus.SetOutput(&logs)
+
+	qCh := make(chan *queue.Task, 1)
+	testTask := &queue.Task{TaskBase: queue.TaskBase{Queue: "testQueue"}, ID: "testTask"}
+	handler := TaskHandlerFunc(func(ctx context.Context, task queue.Task, heartbeats chan<- queue.Progress) error {
+		defer close(heartbeats)
+
+		require.NotNil(t, task)
+		require.Equal(t, testTask.ID, task.ID)
+		require.Equal(t, testTask.Queue, task.Queue)
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.NewTimer(2 * time.Millisecond).C:
+			// mimic a successfull processing
+			heartbeats <- queue.Progress{}
+		}
+
+		return nil
+	})
+
+	allowedFinishedErrors := []error{
+		queue.ErrTaskCancelled, queue.ErrTaskFinished, queue.ErrTaskNotFound, queue.ErrTaskNotRunning,
+	}
+
+	for _, err := range allowedFinishedErrors {
+		t.Run(fmt.Sprintf("%s does not kill worker", err), func(t *testing.T) {
+			logs.Reset()
+			qCh <- testTask
+
+			ctx, cancel := context.WithCancel(ctx)
+
+			w := NewTaskWorker(&mockQueue{queue: qCh, heartbeatErr: err}, handler)
+
+			done := make(chan error)
+			go func() {
+				done <- w.Work(ctx)
+			}()
+
+			time.Sleep(5 * time.Millisecond)
+			cancel()
+			err := <-done
+			// we should get the context error from the Work thread because the dequeue
+			// is not a fatal error, but we should see the dequeue error in the logs
+			require.EqualError(t, err, "context canceled")
+			require.Contains(t, logs.String(), err.Error())
+		})
+	}
+}
+
+type mockQueue struct {
+	queue        chan *queue.Task
+	dequeueErr   error
+	heartbeatErr error
+	finishErr    error
+	failErr      error
+}
+
+func (q *mockQueue) Enqueue(ctx context.Context, task queue.Task, claims authorization.Claims) error {
+	q.queue <- &task
+	return nil
+}
+
+func (q *mockQueue) Dequeue(ctx context.Context, queue ...string) (*queue.Task, error) {
+	if q.dequeueErr != nil {
+		return nil, q.dequeueErr
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case t := <-q.queue:
+		return t, nil
+	}
+
+}
+
+func (q *mockQueue) Heartbeat(ctx context.Context, taskID string, metadata queue.Progress) error {
+	return q.heartbeatErr
+}
+
+func (q *mockQueue) Finish(ctx context.Context, taskID string, metadata queue.Progress) error {
+	return q.finishErr
+}
+
+func (q *mockQueue) Fail(ctx context.Context, taskID string, metadata queue.Progress) error {
+	return q.failErr
+}

--- a/pkg/queue/workers/worker.go
+++ b/pkg/queue/workers/worker.go
@@ -1,0 +1,10 @@
+package workers
+
+import "context"
+
+// Worker provides methods to do some kind of work
+type Worker interface {
+	// Work is responsible for getting and processing tasks
+	// It should run continuously or until the context is cancelled
+	Work(context.Context) error
+}


### PR DESCRIPTION
Changes in order to make this generic:

* change imports
* add `postgres.Setup()` function which bootstraps the db (this has parameters)
  * as a side effect of this the metrics are setup with a usage specific namespace
* the metrics setup is now a bit more complex as it takes a parameter and therefore needs to be called instead of just being global variables
* there are several minor test changes + some new tests to show that the argument propagation works for the setup.