### PR TITLE
Generate const if enum has exactly one element

### DIFF
--- a/pkg/generators/models/enums.go
+++ b/pkg/generators/models/enums.go
@@ -89,7 +89,11 @@ func GenerateEnums(specFile io.Reader, dst string, opts Options) error {
 			return err
 		}
 
-		err = enumTemplate.Execute(f, tctx)
+		if len(tctx.Values) == 1 {
+			err = constTemplate.Execute(f, tctx)
+		} else {
+			err = enumTemplate.Execute(f, tctx)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to generate enum code: %w", err)
 		}
@@ -136,6 +140,12 @@ var enumTemplate = template.Must(
 	template.New("enum").
 		Funcs(fmap).
 		Parse(enumTemplateSource),
+)
+
+var constTemplate = template.Must(
+	template.New("const").
+		Funcs(fmap).
+		Parse(constTemplateSource),
 )
 
 var fmap = template.FuncMap{
@@ -189,4 +199,16 @@ var (
 		{{- end}}
 	)
 )
+`
+
+var constTemplateSource = `
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: {{.SpecTitle}}
+//     Version: {{.SpecVersion}}
+package {{ .PackageName }}
+
+{{ (printf "%s is an enum. %s" .Name .Description) | commentBlock }}
+const {{.VarName}} = {{ (index .Values 0).Value}}
 `

--- a/pkg/generators/models/testdata/model_highlight_indicator_start.go
+++ b/pkg/generators/models/testdata/model_highlight_indicator_start.go
@@ -5,27 +5,5 @@
 //     Version: 0.1.0
 package testpkg
 
-import (
-	validation "github.com/go-ozzo/ozzo-validation"
-)
-
 // HighlightIndicatorStart is an enum.
-type HighlightIndicatorStart string
-
-var (
-	HighlightIndicatorStartValue0 HighlightIndicatorStart = "{{{"
-
-	// KnownHighlightIndicatorStart is the list of valid HighlightIndicatorStart
-	KnownHighlightIndicatorStart = []HighlightIndicatorStart{
-		HighlightIndicatorStartValue0,
-	}
-	// KnownHighlightIndicatorStartString is the list of valid HighlightIndicatorStart as string
-	KnownHighlightIndicatorStartString = []string{
-		string(HighlightIndicatorStartValue0),
-	}
-
-	// InKnownHighlightIndicatorStart is an ozzo-validator for HighlightIndicatorStart
-	InKnownHighlightIndicatorStart = validation.In(
-		HighlightIndicatorStartValue0,
-	)
-)
+const HighlightIndicatorStart = "{{{"


### PR DESCRIPTION
**What**
- Generate a Go `const` if the enum values has exactly one element
- See https://github.com/OAI/OpenAPI-Specification/issues/1313 and
  https://github.com/OAI/OpenAPI-Specification/issues/1620 as examples
  where the openapi team blessed the "singleton enum" example

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>