### PR TITLE
Change the way queue metrics are initialized

### DIFF
--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -15,7 +15,6 @@ func TestQueueMetrics(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	SwitchMetricsNamespace("test")
 
 	numOfTasks := 2
 	qCh := make(chan *Task, numOfTasks)

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -15,8 +15,7 @@ func TestQueueMetrics(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	SetupTaskQueueMetrics("test")
-	SetupSchedulerMetrics("test")
+	SwitchMetricsNamespace("test")
 
 	numOfTasks := 2
 	qCh := make(chan *Task, numOfTasks)

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -97,8 +97,9 @@ var (
 	}
 )
 
-// SwitchMetricsNamespace changes the namespace used in the metrics, so it can be customized
-func SwitchServiceName(serviceName string) {
+// SwitchMetricsServiceName changes the service label used in the metrics,
+// so it can be customized
+func SwitchMetricsServiceName(serviceName string) {
 	newConstLabels := prometheus.Labels{
 		instanceKey: constLabels[instanceKey],
 		serviceKey:  serviceName,

--- a/pkg/queue/metrics.go
+++ b/pkg/queue/metrics.go
@@ -1,20 +1,13 @@
 package queue
 
 import (
-	"sync"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-)
-
-// largest bucket is 5 seconds
-var durationMsBuckets = []float64{10, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000}
-
-var (
-	queueMetricLabels        = []string{"queue"}
-	taskMetricLabels         = []string{"queue", "type"}
-	oneTaskQueueMetricsSetup sync.Once
-	oneSchedulerMetricsSetup sync.Once
 )
 
 // TaskQueueMetricsType provides access to the prometheus metric objects for the task queue
@@ -24,37 +17,6 @@ type TaskQueueMetricsType struct {
 	EnqueueDuration *prometheus.HistogramVec
 }
 
-// TaskQueueMetrics is the global metrics instance for the task queue of this instance
-var TaskQueueMetrics TaskQueueMetricsType
-
-// SetupTaskQueueMetrics must be called before any other call to the metric subsystem happens
-func SetupTaskQueueMetrics(namespace string) {
-	oneTaskQueueMetricsSetup.Do(func() {
-		TaskQueueMetrics = TaskQueueMetricsType{
-			Labels: queueMetricLabels,
-			TaskCounter: promauto.NewCounterVec(
-				prometheus.CounterOpts{
-					Namespace: namespace,
-					Subsystem: "queue",
-					Name:      "task",
-					Help:      "count of tasks that have been enqueued",
-				},
-				taskMetricLabels,
-			),
-			EnqueueDuration: promauto.NewHistogramVec(
-				prometheus.HistogramOpts{
-					Namespace: namespace,
-					Subsystem: "queue",
-					Name:      "enqueue_duration_ms",
-					Help:      "duration the enqueue action in ms",
-					Buckets:   durationMsBuckets,
-				},
-				queueMetricLabels,
-			),
-		}
-	})
-}
-
 // TaskQueueMetricsType provides access to the prometheus metric objects for the scheduler
 type SchedulerMetricsType struct {
 	Labels          []string
@@ -62,32 +24,120 @@ type SchedulerMetricsType struct {
 	ErrorCounter    *prometheus.CounterVec
 }
 
-// SchedulerMetrics is the global metrics instance for the scheduler of this instance
-var SchedulerMetrics SchedulerMetricsType
+var (
+	// largest bucket is 5 seconds
+	durationMsBuckets  = []float64{10, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000}
+	queueMetricLabels  = []string{"queue"}
+	taskMetricLabels   = []string{"queue", "type"}
+	processName        = escapeNamespace(filepath.Base(os.Args[0]))
+	defTaskCounterOpts = prometheus.CounterOpts{
+		Namespace: processName,
+		Subsystem: "queue",
+		Name:      "task",
+		Help:      "count of tasks that have been enqueued",
+	}
+	defEnqueueDurationOpts = prometheus.HistogramOpts{
+		Namespace: processName,
+		Subsystem: "queue",
+		Name:      "enqueue_duration_ms",
+		Help:      "duration the enqueue action in ms",
+		Buckets:   durationMsBuckets,
+	}
+	defScheduleCounterOpts = prometheus.CounterOpts{
+		Namespace: processName,
+		Subsystem: "scheduler",
+		Name:      "task",
+		Help:      "count of tasks that have been scheduled",
+	}
 
-// SetupSchedulerMetrics must be called before any other call to the metric subsystem happens
-func SetupSchedulerMetrics(namespace string) {
-	oneSchedulerMetricsSetup.Do(func() {
-		SchedulerMetrics = SchedulerMetricsType{
-			Labels: queueMetricLabels,
-			ScheduleCounter: promauto.NewCounterVec(
-				prometheus.CounterOpts{
-					Namespace: namespace,
-					Subsystem: "scheduler",
-					Name:      "task",
-					Help:      "count of tasks that have been scheduled",
-				},
-				taskMetricLabels,
-			),
-			ErrorCounter: promauto.NewCounterVec(
-				prometheus.CounterOpts{
-					Namespace: namespace,
-					Subsystem: "scheduler",
-					Name:      "error",
-					Help:      "count of errors while scheduling",
-				},
-				taskMetricLabels,
-			),
+	defSchedulerErrorCounterOpts = prometheus.CounterOpts{
+		Namespace: processName,
+		Subsystem: "scheduler",
+		Name:      "error",
+		Help:      "count of errors while scheduling",
+	}
+
+	// TaskQueueMetrics is the global metrics instance for the task queue of this instance
+	TaskQueueMetrics = TaskQueueMetricsType{
+		Labels: queueMetricLabels,
+		TaskCounter: promauto.NewCounterVec(
+			defTaskCounterOpts,
+			taskMetricLabels,
+		),
+		EnqueueDuration: promauto.NewHistogramVec(
+			defEnqueueDurationOpts,
+			queueMetricLabels,
+		),
+	}
+
+	// SchedulerMetrics is the global metrics instance for the scheduler of this instance
+	SchedulerMetrics = SchedulerMetricsType{
+		Labels: queueMetricLabels,
+		ScheduleCounter: promauto.NewCounterVec(
+			defScheduleCounterOpts,
+			taskMetricLabels,
+		),
+		ErrorCounter: promauto.NewCounterVec(
+			defSchedulerErrorCounterOpts,
+			taskMetricLabels,
+		),
+	}
+)
+
+// SwitchMetricsNamespace changes the namespace used in the metrics, so it can be customized
+func SwitchMetricsNamespace(namespace string) {
+	newTaskCounterOpts := defTaskCounterOpts
+	newTaskCounterOpts.Namespace = namespace
+
+	newEnqueueDurationOpts := defEnqueueDurationOpts
+	newEnqueueDurationOpts.Namespace = namespace
+
+	newScheduleCounterOpts := defScheduleCounterOpts
+	newScheduleCounterOpts.Namespace = namespace
+
+	newSchedulerErrorCounterOpts := defSchedulerErrorCounterOpts
+	newSchedulerErrorCounterOpts.Namespace = namespace
+
+	TaskQueueMetrics = TaskQueueMetricsType{
+		Labels: queueMetricLabels,
+		TaskCounter: promauto.NewCounterVec(
+			newTaskCounterOpts,
+			taskMetricLabels,
+		),
+		EnqueueDuration: promauto.NewHistogramVec(
+			newEnqueueDurationOpts,
+			queueMetricLabels,
+		),
+	}
+
+	// SchedulerMetrics is the global metrics instance for the scheduler of this instance
+	SchedulerMetrics = SchedulerMetricsType{
+		Labels: queueMetricLabels,
+		ScheduleCounter: promauto.NewCounterVec(
+			newScheduleCounterOpts,
+			taskMetricLabels,
+		),
+		ErrorCounter: promauto.NewCounterVec(
+			newSchedulerErrorCounterOpts,
+			taskMetricLabels,
+		),
+	}
+}
+
+func escapeNamespace(str string) string {
+	str = strings.ToLower(str)
+	result := strings.Builder{}
+	for _, rune := range str {
+		if !unicode.IsLetter(rune) && !unicode.IsDigit(rune) {
+			result.WriteRune('_')
+		} else {
+			result.WriteRune(rune)
 		}
-	})
+	}
+
+	if result.Len() == 0 {
+		return "default"
+	}
+
+	return result.String()
 }

--- a/pkg/queue/postgres/dequeuer_test.go
+++ b/pkg/queue/postgres/dequeuer_test.go
@@ -28,7 +28,7 @@ func TestFinish(t *testing.T) {
 
 	name, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, "test", db, nil))
+	require.NoError(t, SetupTables(ctx, db, nil))
 
 	taskID := uuid.NewV4().String()
 	connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
@@ -95,7 +95,7 @@ func TestFail(t *testing.T) {
 
 	name, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, "test", db, nil))
+	require.NoError(t, SetupTables(ctx, db, nil))
 
 	taskID := uuid.NewV4().String()
 
@@ -211,7 +211,7 @@ func TestHeartbeat(t *testing.T) {
 
 	name, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, "test", db, nil))
+	require.NoError(t, SetupTables(ctx, db, nil))
 
 	connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
 	dbListener := pq.NewListener(
@@ -352,7 +352,7 @@ func TestDequeueTicker(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			name, db := dbtest.GetDatabase(t)
 			defer db.Close()
-			require.NoError(t, Setup(ctx, "test", db, nil))
+			require.NoError(t, SetupTables(ctx, db, nil))
 
 			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
 			dbListener := pq.NewListener(
@@ -477,7 +477,7 @@ func TestDequeue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			name, db := dbtest.GetDatabase(t)
 			defer db.Close()
-			require.NoError(t, Setup(ctx, "test", db, nil))
+			require.NoError(t, SetupTables(ctx, db, nil))
 
 			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
 			dbListener := pq.NewListener(
@@ -630,7 +630,7 @@ func TestQueueList(t *testing.T) {
 
 			name, db := dbtest.GetDatabase(t)
 			defer db.Close()
-			require.NoError(t, Setup(ctx, "test", db, nil))
+			require.NoError(t, SetupTables(ctx, db, nil))
 			connStr := "user=contiamo_test password=localdev sslmode=disable dbname=" + name
 			dbListener := pq.NewListener(
 				connStr,

--- a/pkg/queue/postgres/queuer_test.go
+++ b/pkg/queue/postgres/queuer_test.go
@@ -23,7 +23,7 @@ func TestEnqueue(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, "test", db, nil))
+	require.NoError(t, SetupTables(ctx, db, nil))
 	_, err := db.ExecContext(ctx, `ALTER TABLE tasks ADD column test_id uuid;`)
 	require.NoError(t, err)
 

--- a/pkg/queue/postgres/scheduler_test.go
+++ b/pkg/queue/postgres/scheduler_test.go
@@ -24,7 +24,7 @@ func TestSchedule(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, "test", db, nil))
+	require.NoError(t, SetupTables(ctx, db, nil))
 	_, err := db.ExecContext(ctx, `ALTER TABLE schedules ADD column test_id uuid;`)
 	require.NoError(t, err)
 
@@ -161,7 +161,7 @@ func TestEnsure(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, "test", db, nil))
+	require.NoError(t, SetupTables(ctx, db, nil))
 	_, err := db.ExecContext(ctx, `ALTER TABLE schedules ADD column test_id uuid;`)
 	require.NoError(t, err)
 

--- a/pkg/queue/postgres/setup.go
+++ b/pkg/queue/postgres/setup.go
@@ -6,7 +6,6 @@ import (
 	"text/template"
 
 	"github.com/contiamo/go-base/pkg/db"
-	"github.com/contiamo/go-base/pkg/queue"
 )
 
 type ForeignReference struct {
@@ -16,11 +15,7 @@ type ForeignReference struct {
 	ReferencedColumn string
 }
 
-func Setup(ctx context.Context, metricsNamespace string, db db.SQLDB, references []ForeignReference) error {
-	// setup metrics
-	queue.SetupTaskQueueMetrics(metricsNamespace)
-	queue.SetupSchedulerMetrics(metricsNamespace)
-
+func SetupTables(ctx context.Context, db db.SQLDB, references []ForeignReference) error {
 	// setup database
 	buf := &bytes.Buffer{}
 	err := dbSetupTemplate.Execute(buf, references)

--- a/pkg/queue/postgres/setup_test.go
+++ b/pkg/queue/postgres/setup_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetupWithoutReferences(t *testing.T) {
+func TestSetupTablesWithoutReferences(t *testing.T) {
 	logrus.SetOutput(ioutil.Discard)
 	defer logrus.SetOutput(os.Stdout)
 
@@ -22,7 +22,7 @@ func TestSetupWithoutReferences(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, Setup(ctx, "test", db, nil))
+	require.NoError(t, SetupTables(ctx, db, nil))
 }
 
 func TestStupWithReferences(t *testing.T) {
@@ -41,7 +41,7 @@ func TestStupWithReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	// setup with foreign reference
-	err = Setup(ctx, "test", db, []ForeignReference{
+	err = SetupTables(ctx, db, []ForeignReference{
 		{
 			ColumnName:       "entity_id",
 			ColumnType:       "UUID",

--- a/pkg/queue/workers/schedule_worker_test.go
+++ b/pkg/queue/workers/schedule_worker_test.go
@@ -24,7 +24,7 @@ func TestScheduleTask(t *testing.T) {
 	t.Run("Takes a schedule from the queue and enqueues tasks", func(t *testing.T) {
 		_, db := dbtest.GetDatabase(t)
 		defer db.Close()
-		require.NoError(t, postgres.Setup(ctx, "test", db, nil))
+		require.NoError(t, postgres.SetupTables(ctx, db, nil))
 
 		scheduleID1 := uuid.NewV4().String()
 		scheduleID2 := uuid.NewV4().String()
@@ -114,7 +114,7 @@ func TestScheduleTask(t *testing.T) {
 	t.Run("Returns ErrScheduleQueueIsEmpty if there is no task to schedule", func(t *testing.T) {
 		_, db := dbtest.GetDatabase(t)
 		defer db.Close()
-		require.NoError(t, postgres.Setup(ctx, "test", db, nil))
+		require.NoError(t, postgres.SetupTables(ctx, db, nil))
 
 		qm := &queueMock{}
 		w := newScheduleWorker(db, qm, time.Second)
@@ -136,7 +136,7 @@ func TestMetrics(t *testing.T) {
 
 	_, db := dbtest.GetDatabase(t)
 	defer db.Close()
-	require.NoError(t, postgres.Setup(context.TODO(), "test", db, nil))
+	require.NoError(t, postgres.SetupTables(context.TODO(), db, nil))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()


### PR DESCRIPTION
* There are now default metrics, so the queue does not panic in runtime.
* The namespace of the metrics can be easily switched by calling `SwitchMetricsNamespace`, (executed binary name  by default)
* `Setup` function is renamed to `SetupTables` because that's what it's supposed to do.