### PR TITLE
Fix panic when switch to the same service name

### DIFF
--- a/pkg/queue/metrics_test.go
+++ b/pkg/queue/metrics_test.go
@@ -1,0 +1,28 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwitchMetricsServiceName(t *testing.T) {
+	t.Run("does not panic when try to register something that matches default", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			SwitchMetricsServiceName(constLabels[serviceKey])
+		})
+	})
+
+	t.Run("does not panic when try to register something else", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			SwitchMetricsServiceName("test")
+		})
+	})
+
+	t.Run("does not panic when try to register something twice", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			SwitchMetricsServiceName("test")
+			SwitchMetricsServiceName("test")
+		})
+	})
+}


### PR DESCRIPTION
When switch queue metrics to the same name it caused panic in the
Prometheus client we use. Now we properly unregister the previous collectors.