### PR TITLE
Allow one-time jobs in the scheduler

### DIFF
--- a/pkg/queue/postgres/scheduler.go
+++ b/pkg/queue/postgres/scheduler.go
@@ -52,9 +52,12 @@ func (q *scheduler) Schedule(ctx context.Context, builder cdb.SQLBuilder, task q
 		task.Spec = emptyJSON
 	}
 
-	err = cvalidation.CronTab(task.CronSchedule)
-	if err != nil {
-		return err
+	// empty schedule means a one-time job
+	if task.CronSchedule != "" {
+		err = cvalidation.CronTab(task.CronSchedule)
+		if err != nil {
+			return err
+		}
 	}
 
 	scheduleID := uuid.NewV4().String()

--- a/pkg/queue/postgres/scheduler_test.go
+++ b/pkg/queue/postgres/scheduler_test.go
@@ -83,6 +83,18 @@ func TestSchedule(t *testing.T) {
 			},
 		},
 		{
+			name: "Returns no error when a schedule is empty",
+			task: queue.TaskScheduleRequest{
+				TaskBase: queue.TaskBase{
+					Queue: "queue2",
+					Type:  "test",
+					Spec:  spec,
+				},
+				CronSchedule: "",
+			},
+		},
+
+		{
 			name: "Returns error when a cron schedule is not valid",
 			task: queue.TaskScheduleRequest{
 				TaskBase: queue.TaskBase{

--- a/pkg/queue/workers/schedule_worker_test.go
+++ b/pkg/queue/workers/schedule_worker_test.go
@@ -66,7 +66,7 @@ func TestScheduleTask(t *testing.T) {
 				taskQueue2,
 				taskType,
 				taskSpec2,
-				"",
+				"",                      // empty value is a one-time job
 				now.Add(-1*time.Minute), // this must be executed after the first
 				now.Add(-1*time.Minute),
 				now.Add(-1*time.Minute),


### PR DESCRIPTION
Sometimes it's needed to create a job that executes once.