### PR TITLE
Add support for changing references in the queue

### DIFF
--- a/pkg/queue/postgres/setup_test.go
+++ b/pkg/queue/postgres/setup_test.go
@@ -13,61 +13,145 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetupTablesWithoutReferences(t *testing.T) {
-	logrus.SetOutput(ioutil.Discard)
-	defer logrus.SetOutput(os.Stdout)
-
+func TestSetupTables(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_, db := dbtest.GetDatabase(t)
-	defer db.Close()
-	require.NoError(t, SetupTables(ctx, db, nil))
-}
-
-func TestStupWithReferences(t *testing.T) {
 	logrus.SetOutput(ioutil.Discard)
 	defer logrus.SetOutput(os.Stdout)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	_, db := dbtest.GetDatabase(t)
-	defer db.Close()
-
-	_, err := db.ExecContext(ctx, "CREATE TABLE some_entity(id UUID PRIMARY KEY);")
-	require.NoError(t, err)
-	_, err = db.ExecContext(ctx, "INSERT INTO some_entity(id) values('27195537-cc37-40db-acdb-424d448ec805');")
-	require.NoError(t, err)
-
-	// setup with foreign reference
-	err = SetupTables(ctx, db, []ForeignReference{
-		{
-			ColumnName:       "entity_id",
-			ColumnType:       "UUID",
-			ReferencedTable:  "some_entity",
-			ReferencedColumn: "id",
-		},
+	t.Run("bootstraps without references", func(t *testing.T) {
+		_, db := dbtest.GetDatabase(t)
+		defer db.Close()
+		require.NoError(t, SetupTables(ctx, db, nil))
 	})
-	require.NoError(t, err)
 
-	// create a task on the queue using this reference
-	queuer := NewQueuer(db)
-	err = queuer.Enqueue(ctx, queue.TaskEnqueueRequest{
-		TaskBase: queue.TaskBase{
-			Queue: "test-queue",
-			Type:  queue.TaskType("test-task-type"),
-			Spec:  queue.Spec("{}"),
-		},
-		References: queue.References{
-			"entity_id": "27195537-cc37-40db-acdb-424d448ec805",
-		},
+	t.Run("bootstraps with references", func(t *testing.T) {
+		_, db := dbtest.GetDatabase(t)
+		defer db.Close()
+
+		_, err := db.ExecContext(ctx, "CREATE TABLE some_entity(id UUID PRIMARY KEY);")
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, "INSERT INTO some_entity(id) values('27195537-cc37-40db-acdb-424d448ec805');")
+		require.NoError(t, err)
+
+		err = SetupTables(ctx, db, []ForeignReference{
+			{
+				ColumnName:       "entity_id",
+				ColumnType:       "UUID",
+				ReferencedTable:  "some_entity",
+				ReferencedColumn: "id",
+			},
+		})
+		require.NoError(t, err)
+
+		// create a task on the queue using this reference
+		queuer := NewQueuer(db)
+		err = queuer.Enqueue(ctx, queue.TaskEnqueueRequest{
+			TaskBase: queue.TaskBase{
+				Queue: "test-queue",
+				Type:  queue.TaskType("test-task-type"),
+				Spec:  queue.Spec("{}"),
+			},
+			References: queue.References{
+				"entity_id": "27195537-cc37-40db-acdb-424d448ec805",
+			},
+		})
+		require.NoError(t, err)
+		dbtest.EqualCount(t, db, 1, "tasks", nil)
+
+		// delete the entity, and see how the task disappears
+		_, err = db.ExecContext(ctx, "DELETE FROM some_entity;")
+		require.NoError(t, err)
+		dbtest.EqualCount(t, db, 0, "tasks", nil)
+
 	})
-	require.NoError(t, err)
-	dbtest.EqualCount(t, db, 1, "tasks", nil)
 
-	// delete the entity, and see how the task disappears
-	_, err = db.ExecContext(ctx, "DELETE FROM some_entity;")
-	require.NoError(t, err)
-	dbtest.EqualCount(t, db, 0, "tasks", nil)
+	t.Run("returns error when try to override a system column with a reference", func(t *testing.T) {
+		_, db := dbtest.GetDatabase(t)
+		defer db.Close()
+
+		err := SetupTables(ctx, db, []ForeignReference{
+			{
+				ColumnName:       "schedule_id",
+				ColumnType:       "UUID",
+				ReferencedTable:  "schedules",
+				ReferencedColumn: "schedule_id",
+			},
+		})
+		require.Error(t, err)
+		require.Equal(t, "failed to replace a system column \"schedule_id\" with a reference", err.Error())
+	})
+
+	t.Run("adds and drops columns when the references change", func(t *testing.T) {
+		_, db := dbtest.GetDatabase(t)
+		defer db.Close()
+
+		_, err := db.ExecContext(ctx, "CREATE TABLE first(id UUID PRIMARY KEY);")
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, "INSERT INTO first(id) values('27195537-cc37-40db-acdb-424d448ec805');")
+		require.NoError(t, err)
+
+		_, err = db.ExecContext(ctx, "CREATE TABLE second(id UUID PRIMARY KEY);")
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, "INSERT INTO second(id) values('27195537-cc37-40db-acdb-424d448ec806');")
+		require.NoError(t, err)
+
+		err = SetupTables(ctx, db, []ForeignReference{
+			{
+				ColumnName:       "first_id",
+				ColumnType:       "UUID",
+				ReferencedTable:  "first",
+				ReferencedColumn: "id",
+			},
+		})
+		require.NoError(t, err)
+
+		// now change the references
+		err = SetupTables(ctx, db, []ForeignReference{
+			{
+				ColumnName:       "second_id",
+				ColumnType:       "UUID",
+				ReferencedTable:  "second",
+				ReferencedColumn: "id",
+			},
+		})
+		require.NoError(t, err)
+
+		queuer := NewQueuer(db)
+
+		// try create a task on the queue using the old reference
+		err = queuer.Enqueue(ctx, queue.TaskEnqueueRequest{
+			TaskBase: queue.TaskBase{
+				Queue: "test-queue",
+				Type:  queue.TaskType("test-task-type"),
+				Spec:  queue.Spec("{}"),
+			},
+			References: queue.References{
+				"first_id": "27195537-cc37-40db-acdb-424d448ec805",
+			},
+		})
+		require.Error(t, err)
+		require.Equal(t, "pq: column \"first_id\" of relation \"tasks\" does not exist", err.Error())
+		dbtest.EqualCount(t, db, 0, "tasks", nil)
+
+		err = queuer.Enqueue(ctx, queue.TaskEnqueueRequest{
+			TaskBase: queue.TaskBase{
+				Queue: "test-queue",
+				Type:  queue.TaskType("test-task-type"),
+				Spec:  queue.Spec("{}"),
+			},
+			References: queue.References{
+				"second_id": "27195537-cc37-40db-acdb-424d448ec806",
+			},
+		})
+		require.NoError(t, err)
+		dbtest.EqualCount(t, db, 1, "tasks", nil)
+
+		// delete the entity, and see how the task disappears
+		_, err = db.ExecContext(ctx, "DELETE FROM second;")
+		require.NoError(t, err)
+		dbtest.EqualCount(t, db, 0, "tasks", nil)
+
+	})
 }

--- a/pkg/strings/casing.go
+++ b/pkg/strings/casing.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"strings"
+	"unicode"
+)
+
+// ToPascalCase returns a pascal-cased (e.g. SomeValueLikeThis) out of a string
+func ToPascalCase(value string) string {
+	b := strings.Builder{}
+
+	var toUpper bool
+
+	for i, rune := range value {
+		// Always upper the first character
+		if i == 0 {
+			toUpper = true
+		}
+		// Always upper the character after non-letter/non-digit skipping the character
+		if !unicode.IsLetter(rune) && !unicode.IsDigit(rune) {
+			toUpper = true
+			continue
+		}
+		// If the flag was set by one of the previous steps
+		if toUpper {
+			rune = unicode.ToUpper(rune)
+			toUpper = false
+		}
+
+		b.WriteRune(rune)
+	}
+
+	return b.String()
+}
+
+// ToUnderscoreCase returns a underscore-cased (e.g. some_value_like_this) out of a string
+func ToUnderscoreCase(value string) string {
+	b := strings.Builder{}
+
+	for _, rune := range value {
+		// Always upper the character after non-letter/non-digit skipping the character
+		if !unicode.IsLetter(rune) && !unicode.IsDigit(rune) {
+			b.WriteByte('_')
+			continue
+		}
+
+		// convert pascal or camel case into underscore case
+		if unicode.IsUpper(rune) {
+			b.WriteByte('_')
+		}
+
+		b.WriteRune(unicode.ToLower(rune))
+	}
+
+	return strings.Trim(b.String(), "_")
+}

--- a/pkg/strings/casing_test.go
+++ b/pkg/strings/casing_test.go
@@ -1,0 +1,96 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToPascalCase(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name:   "Converts underscore casing to pascal casing",
+			input:  "some_table_name",
+			output: "SomeTableName",
+		},
+		{
+			name:   "Converts mixed casing",
+			input:  "some_table_nameSomeName",
+			output: "SomeTableNameSomeName",
+		},
+		{
+			name:   "Does not change the value if it's pascal casing",
+			input:  "SomeName",
+			output: "SomeName",
+		},
+		{
+			name:   "Trims single bad character at the end",
+			input:  "Some{",
+			output: "Some",
+		},
+		{
+			name:   "Trims multiple bad characters at the end",
+			input:  "Some{{{",
+			output: "Some",
+		},
+
+		{
+			name: "Handles empty string",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.output, ToPascalCase(tc.input))
+		})
+	}
+}
+
+func TestToUnderscoreCase(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+
+			name:   "Converts pascal casing to underscore casing",
+			input:  "SomeTableName",
+			output: "some_table_name",
+		},
+		{
+			name:   "Converts mixed casing",
+			input:  "some_table_nameSomeName",
+			output: "some_table_name_some_name",
+		},
+		{
+			name:   "Does not change the value if it's underscore casing",
+			input:  "some_name",
+			output: "some_name",
+		},
+		{
+			name:   "Trims single bad character at the end",
+			input:  "Some{",
+			output: "some",
+		},
+		{
+			name:   "Trims multiple bad characters at the end",
+			input:  "Some{{{",
+			output: "some",
+		},
+
+		{
+			name: "Handles empty string",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.output, ToUnderscoreCase(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
Now it's possible to change both:

* list of system columns in `tasks` and `schedules`
* list of user defined references of the queue item

Only adding or removing of columns is supported, once it's created
it's not going to be edited only dropped if removed from the list.

Also, added some string functions for casing conversions.