### PR TITLE
Create task retention worker and scheduler

### DIFF
--- a/pkg/db/test/db.go
+++ b/pkg/db/test/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -28,7 +29,7 @@ type DBInitializer func(context.Context, *sql.DB) error
 
 // EqualCount asserts that the count of rows matches the expected value given the table and WHERE query and args.EqualCount
 // Note that this is a simple  COUNT of rows in a single table. More complex queries should be constructed by hand.
-func EqualCount(t *testing.T, db *sql.DB, expected int, table string, filter squirrel.Sqlizer) int {
+func EqualCount(t *testing.T, db *sql.DB, expected int, table string, filter squirrel.Sqlizer, msgAndArgs ...interface{}) int {
 	var count int
 	err := squirrel.StatementBuilder.
 		PlaceholderFormat(squirrel.Dollar).
@@ -37,8 +38,8 @@ func EqualCount(t *testing.T, db *sql.DB, expected int, table string, filter squ
 		Where(filter).
 		RunWith(db).
 		Scan(&count)
-	require.NoError(t, err)
-	require.Equal(t, expected, count)
+	require.NoError(t, err, msgAndArgs...)
+	require.Equal(t, expected, count, msgAndArgs...)
 
 	return count
 }
@@ -111,4 +112,60 @@ func connectDB(name string) (db *sql.DB, err error) {
 	}
 
 	return sql.Open(cfg.DriverName, connStr+" password="+adminPassword)
+}
+
+// cleanupDB attempts to remove the test container created by EnsureDBReady
+func cleanupDB() {
+	cmd := exec.Command("docker", "rm", "-v", "-f", "go-base-postgres")
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("error during db cleanupdb: ", err)
+	}
+}
+
+// EnsureDBReady is a helper utility that can be inserted into a test during development to make it simpler
+// to run the test in isolation. Docker will be called to start a db that is read  to be used with GetDatabase.
+// Example usage:
+//
+//   err, cleanup := dbtest.EnsureDBReady(ctx)
+//   require.NoError(t, err)
+//   defer cleanup()
+//
+//   _, db := dbtest.GetDatabase(t)
+//   defer db.Close()
+//
+// While the code is somewhat robust to having existing dbs running, this is not intended to be left in the test code.
+// The goal is that you can run individual tests via your IDE integrations or using the CLI, e.g.
+//   go test -run ^TestRetentionHandler$`
+func EnsureDBReady(ctx context.Context) (error, func()) {
+	check := exec.CommandContext(ctx, "docker", "container", "inspect", "go-base-postgres", "-f", "{{.ID}}").Run()
+	if check == nil {
+		// container is already running, non
+		return nil, func() {}
+	}
+
+	if exitError, ok := check.(*exec.ExitError); ok && exitError.ExitCode() != 1 {
+		return fmt.Errorf("unexpected exit code when checking for running db: %w", check), func() {}
+	}
+
+	db := exec.CommandContext(ctx,
+		"docker",
+		"run",
+		"--rm",
+		"-d",
+		"--name", "go-base-postgres",
+		"-p", "0.0.0.0:5432:5432",
+		"-e", "POSTGRES_PASSWORD=localdev",
+		"-e", "POSTGRES_USER=contiamo_test",
+		"-e", "POSTGRES_DB=postgres",
+		"postgres:alpine",
+		"-c", "fsync=off",
+		"-c", "full_page_writes=off",
+		"-c", "synchronous_commit=off",
+	)
+
+	err := db.Run()
+
+	time.Sleep(3 * time.Second)
+	return err, cleanupDB
 }

--- a/pkg/db/test/db.go
+++ b/pkg/db/test/db.go
@@ -140,7 +140,7 @@ func cleanupDB() {
 func EnsureDBReady(ctx context.Context) (error, func()) {
 	check := exec.CommandContext(ctx, "docker", "container", "inspect", "go-base-postgres", "-f", "{{.ID}}").Run()
 	if check == nil {
-		// container is already running, non
+		// container is already running
 		return nil, func() {}
 	}
 

--- a/pkg/queue/postgres/setup.go
+++ b/pkg/queue/postgres/setup.go
@@ -11,6 +11,11 @@ import (
 )
 
 const (
+	// TasksTable is the name of the Postgres table that is used for tasks
+	TasksTable = "tasks"
+	// SchedulesTable is the name of the Postgres table used for schedules
+	SchedulesTable = "schedules"
+
 	createTableTmpl = `
 CREATE EXTENSION IF NOT EXISTS citext;
 
@@ -80,71 +85,71 @@ var (
 
 		// schedules
 		{
-			Table:   "schedules",
+			Table:   SchedulesTable,
 			Columns: []string{"next_execution_time DESC"},
 		},
 		{
-			Table:   "schedules",
+			Table:   SchedulesTable,
 			Columns: []string{"task_queue"},
 			Type:    "hash",
 		},
 		{
-			Table:   "schedules",
+			Table:   SchedulesTable,
 			Columns: []string{"task_type"},
 			Type:    "hash",
 		},
 		{
-			Table:   "schedules",
+			Table:   SchedulesTable,
 			Columns: []string{"created_at DESC", "updated_at DESC"},
 		},
 
 		// tasks
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"queue"},
 			Type:    "hash",
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"type"},
 			Type:    "hash",
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"status"},
 			Type:    "hash",
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"schedule_id"},
 			Type:    "hash",
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"created_at", "last_heartbeat_at"},
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"created_at DESC", "last_heartbeat_at DESC"},
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"created_at DESC"},
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"last_heartbeat_at DESC"},
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"created_at DESC", "updated_at DESC"},
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"started_at DESC"},
 		},
 		{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{"finished_at DESC"},
 		},
 	}
@@ -170,14 +175,14 @@ func SetupTables(ctx context.Context, db db.SQLDB, references []ForeignReference
 	logrus.Debug("checking queue-related tables...")
 
 	logrus.Debug("checking `schedules` table...")
-	err = syncTable(ctx, db, "schedules", scheduleColumns, references)
+	err = syncTable(ctx, db, SchedulesTable, scheduleColumns, references)
 	if err != nil {
 		return err
 	}
 	logrus.Debug("`schedules` table is up to date")
 
 	logrus.Debug("checking `tasks` table...")
-	err = syncTable(ctx, db, "tasks", taskColumns, references)
+	err = syncTable(ctx, db, TasksTable, taskColumns, references)
 	if err != nil {
 		return err
 	}
@@ -194,12 +199,12 @@ func SetupTables(ctx context.Context, db db.SQLDB, references []ForeignReference
 	applyIndexes := make(indexList, 0, len(references)+len(indexes))
 	for _, ref := range references {
 		applyIndexes = append(applyIndexes, index{
-			Table:   "schedules",
+			Table:   SchedulesTable,
 			Columns: []string{ref.ColumnName},
 			Type:    "hash",
 		})
 		applyIndexes = append(applyIndexes, index{
-			Table:   "tasks",
+			Table:   TasksTable,
 			Columns: []string{ref.ColumnName},
 			Type:    "hash",
 		})

--- a/pkg/queue/workers/retention.go
+++ b/pkg/queue/workers/retention.go
@@ -1,0 +1,204 @@
+package workers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/contiamo/go-base/pkg/queue"
+	"github.com/contiamo/go-base/pkg/queue/postgres"
+	"github.com/contiamo/go-base/pkg/tracing"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// MaintenanceTaskQueue task queue name used for all the periodic maintenance jobs.
+	// These are internal queue internal tasks
+	MaintenanceTaskQueue string = "queue-maintenance"
+
+	// RetentionTask is finished task cleanup type
+	RetentionTask queue.TaskType = "retention"
+)
+
+var (
+	errSerializingHearbeat = errors.New("failed to serialize progress payload while sending heartbeat")
+)
+
+type retentionProgress struct {
+	// Duration of the HTTP request in milliseconds
+	Duration *int64 `json:"duration,omitempty"`
+	// RowsAffected
+	RowsAffected *int64 `json:"rowsAffected,omitempty"`
+	// ErrorMessage contains an error message string if it occurs during the update process
+	ErrorMessage *string `json:"errorMessage,omitempty"`
+}
+
+type retentionSpec struct {
+	// QueueName determine which queue the retention policy applies to
+	QueueName string `json:"queueName"`
+	// TaskType determines which task type the retention policy applies to
+	TaskType queue.TaskType `json:"taskType"`
+	// Status is the required status the task must have to be deleted
+	Status queue.TaskStatus `json:"status"`
+	// Age is the time since finish when the task will be considered for deletion
+	Age time.Duration `json:"age"`
+	// SQL is the actual sql that will be run
+	SQL string `json:"sql"`
+}
+
+// NewRetentionHandler creates a task handler that will clean up old finished tasks
+func NewRetentionHandler(db *sql.DB) TaskHandler {
+	return &retentionHandler{
+		Tracer: tracing.NewTracer("handlers", "RetentionHandler"),
+		db:     db,
+	}
+}
+
+type retentionHandler struct {
+	tracing.Tracer
+	db *sql.DB
+}
+
+func (h *retentionHandler) Process(ctx context.Context, task queue.Task, heartbeats chan<- queue.Progress) (err error) {
+	span, ctx := h.StartSpan(ctx, "Process")
+	defer func() {
+		h.FinishSpan(span, err)
+	}()
+	span.SetTag("task.id", task.ID)
+	span.SetTag("task.queue", task.Queue)
+	span.SetTag("task.type", task.Type)
+	span.SetTag("task.spec", string(task.Spec))
+
+	log := logrus.WithContext(ctx).WithField("type", task.Type)
+	log.Debug("starting retention task")
+
+	var progress retentionProgress
+	defer func() {
+		// we check for errSerializingHearbeat so we don't cause
+		// a recursion call
+		if err == nil || err == errSerializingHearbeat {
+			return
+		}
+		message := err.Error()
+		progress.ErrorMessage = &message
+		_ = sendRetentionProgress(progress, heartbeats)
+	}()
+
+	spec := retentionSpec{}
+	err = json.Unmarshal(task.Spec, &spec)
+	if err != nil {
+		return fmt.Errorf("can not parse the retention task spec %w", err)
+	}
+
+	span.SetTag("spec.queue", spec.QueueName)
+	span.SetTag("spec.taskType", spec.TaskType)
+	span.SetTag("spec.status", spec.Status)
+	span.SetTag("spec.age", spec.Age.String())
+
+	// initial heartbeat
+	err = sendRetentionProgress(progress, heartbeats)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	result, err := h.db.ExecContext(ctx, spec.SQL)
+	duration := time.Since(now).Milliseconds()
+	progress.Duration = &duration
+
+	if err != nil {
+		return fmt.Errorf("retention execution failed: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("can not get rows affected: %w", err)
+	}
+
+	progress.RowsAffected = &rowsAffected
+	err = sendRetentionProgress(progress, heartbeats)
+	if err != nil {
+		return err
+	}
+
+	log.WithField("rowCount", rowsAffected).Debug("retention finished")
+	return nil
+}
+
+func sendRetentionProgress(progress retentionProgress, heartbeats chan<- queue.Progress) (err error) {
+	logrus.
+		WithField("method", "sendRetentionProgress").
+		Debugf("%+v", progress)
+
+	bytes, err := json.Marshal(progress)
+	if err != nil {
+		logrus.Error(err)
+		return errSerializingHearbeat
+	}
+
+	heartbeats <- bytes
+	return nil
+}
+
+// AssertRetentionSchedule creates a new queue retention tasks for the supplied queue, finished tasks matching
+// the supplied parameters will be deleted
+func AssertRetentionSchedule(ctx context.Context, scheduler queue.Scheduler, queueName string, taskType queue.TaskType, status queue.TaskStatus, filter squirrel.Sqlizer, age time.Duration) error {
+	spec := createRetentionSpec(queueName, taskType, status, filter, age)
+	specBytes, err := json.Marshal(spec)
+	if err != nil {
+		return fmt.Errorf("can not build retention task spec: %w", err)
+	}
+	// randomly distribute the retention tasks throughout the hour
+	when := rand.Intn(60)
+	retentionSchedule := queue.TaskScheduleRequest{
+		TaskBase: queue.TaskBase{
+			Queue: MaintenanceTaskQueue,
+			Type:  RetentionTask,
+			Spec:  specBytes,
+		},
+		CronSchedule: fmt.Sprintf("%d * * * *", when), // every hour at minute "when"
+	}
+
+	return scheduler.AssertSchedule(ctx, retentionSchedule)
+}
+
+//createRetentionSpec builds the task retention job spec. It is split out to simplify test setup
+func createRetentionSpec(queueName string, taskType queue.TaskType, status queue.TaskStatus, filter squirrel.Sqlizer, age time.Duration) retentionSpec {
+	spec := retentionSpec{
+		QueueName: queueName,
+		TaskType:  taskType,
+		Status:    status,
+		Age:       age,
+		SQL:       "",
+	}
+
+	// use sepqrate WHERE statements to make the order deterministic
+	deletionSQL := squirrel.Delete(postgres.TasksTable).
+		Where(squirrel.Eq{"status": status}).
+		Where(
+			// note that using this comparision allows us to use the index on
+			// finished_at, if yo use `age(now(), finished_at)`, this can not use the index
+			fmt.Sprintf("finished_at <= now() - interval '%f minutes'", age.Minutes()),
+		)
+
+	if queueName != "" {
+		deletionSQL = deletionSQL.Where(squirrel.Eq{"queue": queueName})
+	}
+
+	if taskType != "" {
+		deletionSQL = deletionSQL.Where(squirrel.Eq{"type": taskType})
+	}
+
+	if filter != nil {
+		deletionSQL = deletionSQL.Where(filter)
+	}
+
+	spec.SQL = squirrel.DebugSqlizer(deletionSQL)
+
+	return spec
+}

--- a/pkg/queue/workers/retention_test.go
+++ b/pkg/queue/workers/retention_test.go
@@ -1,0 +1,319 @@
+package workers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	cdb "github.com/contiamo/go-base/pkg/db"
+
+	"github.com/Masterminds/squirrel"
+	dbtest "github.com/contiamo/go-base/pkg/db/test"
+	"github.com/contiamo/go-base/pkg/queue"
+	"github.com/contiamo/go-base/pkg/queue/postgres"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+var emptyJSON = []byte("{}")
+
+func TestRetentionHandler(t *testing.T) {
+	logrus.SetOutput(ioutil.Discard)
+	defer logrus.SetOutput(os.Stdout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, db := dbtest.GetDatabase(t)
+	defer db.Close()
+	require.NoError(t, postgres.SetupTables(ctx, db, nil))
+
+	// Start test setup
+	now := time.Now()
+	fiveMinutesAgo := now.Add(-5 * time.Minute)
+	tenMinutesAgo := now.Add(-10 * time.Minute)
+	twoWeeksAgo := now.Add(-14 * 24 * time.Hour)
+
+	waitingTask := queue.Task{
+		TaskBase: queue.TaskBase{
+			Queue: "standard",
+			Type:  queue.TaskType("simple"),
+			Spec:  emptyJSON,
+		},
+		ID:        uuid.NewV4().String(),
+		CreatedAt: now.Add(-5 * time.Minute),
+		Status:    queue.Waiting,
+	}
+	require.NoError(t, insertTestTask(ctx, db, &waitingTask))
+
+	runningTask := queue.Task{
+		TaskBase: queue.TaskBase{
+			Queue: "standard",
+			Type:  queue.TaskType("simple"),
+			Spec:  emptyJSON,
+		},
+		ID:              uuid.NewV4().String(),
+		CreatedAt:       now.Add(-5 * time.Minute),
+		StartedAt:       &now,
+		LastHeartbeatAt: &now,
+		Status:          queue.Running,
+	}
+	require.NoError(t, insertTestTask(ctx, db, &runningTask))
+
+	finishedTask := queue.Task{
+		TaskBase: queue.TaskBase{
+			Queue: "standard",
+			Type:  queue.TaskType("simple"),
+			Spec:  emptyJSON,
+		},
+		ID:              uuid.NewV4().String(),
+		CreatedAt:       now.Add(-60 * time.Minute),
+		StartedAt:       &tenMinutesAgo,
+		UpdatedAt:       fiveMinutesAgo,
+		FinishedAt:      &fiveMinutesAgo,
+		LastHeartbeatAt: &fiveMinutesAgo,
+		Status:          queue.Finished,
+	}
+	require.NoError(t, insertTestTask(ctx, db, &finishedTask))
+
+	twoWeeksAgoPlus10 := twoWeeksAgo.Add(10 * time.Minute)
+	toBeRemoved := queue.Task{
+		TaskBase: queue.TaskBase{
+			Queue: "standard",
+			Type:  queue.TaskType("simple"),
+			Spec:  emptyJSON,
+		},
+		ID:              uuid.NewV4().String(),
+		CreatedAt:       twoWeeksAgo.Add(-10 * time.Minute),
+		StartedAt:       &twoWeeksAgo,
+		UpdatedAt:       twoWeeksAgoPlus10,
+		FinishedAt:      &twoWeeksAgoPlus10,
+		LastHeartbeatAt: &twoWeeksAgoPlus10,
+		Status:          queue.Finished,
+	}
+	require.NoError(t, insertTestTask(ctx, db, &toBeRemoved))
+	// Test db is now prepared
+
+	// Now test the handler
+	sevenDays := 7 * 24 * time.Hour
+	spec := createRetentionSpec("standard", "", queue.Finished, nil, sevenDays)
+	specBytes, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	retentionTask := queue.Task{
+		TaskBase: queue.TaskBase{
+			Queue: MaintenanceTaskQueue,
+			Type:  RetentionTask,
+			Spec:  specBytes,
+		},
+		ID:        uuid.NewV4().String(),
+		CreatedAt: now,
+	}
+
+	heartbeats := make(chan queue.Progress, 10)
+
+	seenBeats := []retentionProgress{}
+	go func() {
+		for hb := range heartbeats {
+			progress := retentionProgress{}
+			err = json.Unmarshal(hb, &progress)
+			require.NoError(t, err, "can't parse progress")
+			seenBeats = append(seenBeats, progress)
+		}
+	}()
+
+	handler := NewRetentionHandler(db)
+	err = handler.Process(ctx, retentionTask, heartbeats)
+	require.NoError(t, err, "processing error")
+
+	dbtest.EqualCount(t, db, 0, postgres.TasksTable, squirrel.Eq{
+		"task_id": toBeRemoved.ID,
+	}, "found toBeRemoved when it should be deleted")
+	dbtest.EqualCount(t, db, 1, postgres.TasksTable, squirrel.Eq{
+		"task_id": finishedTask.ID,
+	}, "can not find finishedTask")
+	dbtest.EqualCount(t, db, 1, postgres.TasksTable, squirrel.Eq{
+		"task_id": runningTask.ID,
+	}, "can not find runningTask")
+	dbtest.EqualCount(t, db, 1, postgres.TasksTable, squirrel.Eq{
+		"task_id": waitingTask.ID,
+	}, "can not find waitingTask")
+
+	dbtest.EqualCount(t, db, 3, postgres.TasksTable, nil, "incorrect task count")
+
+	// wait a moment for the final heartbeat and then close the channel to avoid
+	// goroutine leak errors
+	time.Sleep(time.Second)
+	close(heartbeats)
+
+	require.Equal(t, retentionProgress{}, seenBeats[0])
+
+	lastBeat := seenBeats[len(seenBeats)-1]
+
+	require.Nil(t, lastBeat.ErrorMessage)
+	require.NotNil(t, lastBeat.Duration)
+	require.NotNil(t, lastBeat.RowsAffected)
+	require.Equal(t, int64(1), *lastBeat.RowsAffected, "%+v", seenBeats)
+}
+
+func insertTestTask(ctx context.Context, db *sql.DB, task *queue.Task) error {
+	_, err := squirrel.StatementBuilder.
+		PlaceholderFormat(squirrel.Dollar).
+		RunWith(db).
+		Insert("tasks").
+		Columns(
+			"task_id",
+			"queue",
+			"type",
+			"spec",
+			"status",
+			"progress",
+			"created_at",
+			"updated_at",
+			"started_at",
+			"finished_at",
+			"last_heartbeat_at",
+		).
+		Values(
+			task.ID,
+			task.Queue,
+			task.Type,
+			task.Spec,
+			task.Status,
+			emptyJSON,
+			task.CreatedAt,
+			task.UpdatedAt,
+			task.StartedAt,
+			task.FinishedAt,
+			task.LastHeartbeatAt,
+		).
+		ExecContext(ctx)
+	return err
+}
+
+func TestAssertRetentionSchedule(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cases := []struct {
+		name        string
+		queueName   string
+		taskType    queue.TaskType
+		status      queue.TaskStatus
+		age         time.Duration
+		filter      squirrel.Sqlizer
+		expectedSQL string
+	}{
+		{
+			name:        "retention without any extra filters is successful",
+			queueName:   "basic",
+			taskType:    queue.TaskType("throw-away"),
+			status:      queue.Finished,
+			age:         time.Minute,
+			expectedSQL: `DELETE FROM tasks WHERE status = 'finished' AND finished_at <= now() - interval '1.000000 minutes' AND queue = 'basic' AND type = 'throw-away'`,
+		},
+		{
+			name:        "one week retention without any extra filters is successful",
+			queueName:   "advanced",
+			taskType:    queue.TaskType("throw-away-2"),
+			status:      queue.Finished,
+			age:         7 * 24 * time.Hour,
+			expectedSQL: `DELETE FROM tasks WHERE status = 'finished' AND finished_at <= now() - interval '10080.000000 minutes' AND queue = 'advanced' AND type = 'throw-away-2'`,
+		},
+		{
+			name:        "one month retention without any extra filters is successful",
+			queueName:   "super",
+			taskType:    queue.TaskType("throw-away-3"),
+			status:      queue.Finished,
+			age:         30 * 24 * time.Hour,
+			expectedSQL: `DELETE FROM tasks WHERE status = 'finished' AND finished_at <= now() - interval '43200.000000 minutes' AND queue = 'super' AND type = 'throw-away-3'`,
+		},
+		{
+			name:        "retention with additional sql filter is successful",
+			queueName:   "basic",
+			taskType:    queue.TaskType("throw-away"),
+			status:      queue.Failed,
+			age:         time.Minute,
+			filter:      squirrel.Eq{"resource_id": 101},
+			expectedSQL: `DELETE FROM tasks WHERE status = 'failed' AND finished_at <= now() - interval '1.000000 minutes' AND queue = 'basic' AND type = 'throw-away' AND resource_id = '101'`,
+		},
+		{
+			name:        "retention with complex subquery filter",
+			queueName:   "basic",
+			taskType:    queue.TaskType("throw-away"),
+			status:      queue.Finished,
+			age:         time.Minute,
+			filter:      squirrel.Expr("resource_id IN (SELECT resource_id FROM resources WHERE project_id = ?)", "abc"),
+			expectedSQL: `DELETE FROM tasks WHERE status = 'finished' AND finished_at <= now() - interval '1.000000 minutes' AND queue = 'basic' AND type = 'throw-away' AND resource_id IN (SELECT resource_id FROM resources WHERE project_id = 'abc')`,
+		},
+		{
+			name:        "retention for _any_ finished task, without queue or task type restriction",
+			status:      queue.Finished,
+			age:         time.Minute,
+			expectedSQL: `DELETE FROM tasks WHERE status = 'finished' AND finished_at <= now() - interval '1.000000 minutes'`,
+		},
+		{
+			name:        "retention for _any_ failed task in a specific queue",
+			queueName:   "justme",
+			status:      queue.Failed,
+			age:         time.Minute,
+			expectedSQL: `DELETE FROM tasks WHERE status = 'failed' AND finished_at <= now() - interval '1.000000 minutes' AND queue = 'justme'`,
+		},
+		{
+			name:        "retention based on task type and status",
+			taskType:    "justme",
+			status:      queue.Failed,
+			age:         time.Minute,
+			expectedSQL: `DELETE FROM tasks WHERE status = 'failed' AND finished_at <= now() - interval '1.000000 minutes' AND type = 'justme'`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := schedulerMock{}
+			err := AssertRetentionSchedule(ctx, &mock, tc.queueName, tc.taskType, tc.status, tc.filter, tc.age)
+			require.NoError(t, err, "unexpected assert error")
+
+			require.Equal(t, MaintenanceTaskQueue, mock.schedule.Queue)
+			require.Equal(t, RetentionTask, mock.schedule.Type)
+
+			spec := retentionSpec{}
+			err = json.Unmarshal(mock.schedule.Spec, &spec)
+			require.NoError(t, err, "can not parse the task spec")
+
+			require.Equal(t, tc.queueName, spec.QueueName)
+			require.Equal(t, tc.taskType, spec.TaskType)
+			require.Equal(t, tc.status, spec.Status)
+			require.Equal(t, tc.age, spec.Age)
+			require.Equal(t, tc.expectedSQL, spec.SQL)
+			require.Regexp(t, regexp.MustCompile(`\d{1,2} * * * *`), mock.schedule.CronSchedule)
+		})
+	}
+}
+
+// schedulerMock implement scheduler with very simple counters for testing
+type schedulerMock struct {
+	schedule queue.TaskScheduleRequest
+
+	AssertError error
+}
+
+func (s *schedulerMock) Schedule(ctx context.Context, builder cdb.SQLBuilder, task queue.TaskScheduleRequest) (err error) {
+	return fmt.Errorf("do not call Schedule")
+}
+
+func (s *schedulerMock) EnsureSchedule(ctx context.Context, builder cdb.SQLBuilder, task queue.TaskScheduleRequest) error {
+	return fmt.Errorf("do not call EnsureSchedule")
+}
+
+func (s *schedulerMock) AssertSchedule(ctx context.Context, task queue.TaskScheduleRequest) error {
+	s.schedule = task
+	return s.AssertError
+}

--- a/pkg/queue/workers/retention_test.go
+++ b/pkg/queue/workers/retention_test.go
@@ -119,10 +119,10 @@ func TestRetentionHandler(t *testing.T) {
 
 	heartbeats := make(chan queue.Progress, 10)
 
-	seenBeats := []retentionProgress{}
+	seenBeats := []SQLTaskProgress{}
 	go func() {
 		for hb := range heartbeats {
-			progress := retentionProgress{}
+			progress := SQLTaskProgress{}
 			err = json.Unmarshal(hb, &progress)
 			require.NoError(t, err, "can't parse progress")
 			seenBeats = append(seenBeats, progress)
@@ -153,7 +153,7 @@ func TestRetentionHandler(t *testing.T) {
 	time.Sleep(time.Second)
 	close(heartbeats)
 
-	require.Equal(t, retentionProgress{}, seenBeats[0])
+	require.Equal(t, SQLTaskProgress{}, seenBeats[0])
 
 	lastBeat := seenBeats[len(seenBeats)-1]
 
@@ -284,14 +284,10 @@ func TestAssertRetentionSchedule(t *testing.T) {
 			require.Equal(t, MaintenanceTaskQueue, mock.schedule.Queue)
 			require.Equal(t, RetentionTask, mock.schedule.Type)
 
-			spec := retentionSpec{}
+			spec := SQLExecTaskSpec{}
 			err = json.Unmarshal(mock.schedule.Spec, &spec)
 			require.NoError(t, err, "can not parse the task spec")
 
-			require.Equal(t, tc.queueName, spec.QueueName)
-			require.Equal(t, tc.taskType, spec.TaskType)
-			require.Equal(t, tc.status, spec.Status)
-			require.Equal(t, tc.age, spec.Age)
 			require.Equal(t, tc.expectedSQL, spec.SQL)
 			require.Regexp(t, regexp.MustCompile(`\d{1,2} * * * *`), mock.schedule.CronSchedule)
 		})

--- a/pkg/queue/workers/sql_task.go
+++ b/pkg/queue/workers/sql_task.go
@@ -1,0 +1,129 @@
+package workers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/contiamo/go-base/pkg/queue"
+	"github.com/contiamo/go-base/pkg/tracing"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	errSerializingHearbeat = errors.New("failed to serialize progress payload while sending heartbeat")
+)
+
+// SQLTaskProgress contains the generic progress information for a sql task
+type SQLTaskProgress struct {
+	// Duration of the HTTP request in milliseconds
+	Duration *int64 `json:"duration,omitempty"`
+	// RowsAffected
+	RowsAffected *int64 `json:"rowsAffected,omitempty"`
+	// ErrorMessage contains an error message string if it occurs during the update process
+	ErrorMessage *string `json:"errorMessage,omitempty"`
+}
+
+// SQLExecTaskSpec  defines a task that simply executes a single SQL statement. This can
+// be used for simple CRON cleanup tasks, for example.
+type SQLExecTaskSpec struct {
+	// SQL is the actual sql that will be run
+	SQL string `json:"sql"`
+}
+
+type sqlTaskHandler struct {
+	tracing.Tracer
+	db *sql.DB
+}
+
+// NewSQLTaskHandler creates a sqlTaskHandler handler instance with the given tracing name
+func NewSQLTaskHandler(name string, db *sql.DB) TaskHandler {
+	return &sqlTaskHandler{
+		Tracer: tracing.NewTracer("handlers", name),
+		db:     db,
+	}
+}
+
+func (h *sqlTaskHandler) Process(ctx context.Context, task queue.Task, heartbeats chan<- queue.Progress) (err error) {
+	span, ctx := h.StartSpan(ctx, "Process")
+	defer func() {
+		h.FinishSpan(span, err)
+	}()
+	span.SetTag("task.id", task.ID)
+	span.SetTag("task.queue", task.Queue)
+	span.SetTag("task.type", task.Type)
+
+	log := logrus.WithContext(ctx).
+		WithField("id", task.ID).
+		WithField("type", task.Type).
+		WithField("queue", task.Queue)
+	log.Debug("starting sql task")
+
+	var progress SQLTaskProgress
+	defer func() {
+		// we check for errSerializingHearbeat so we don't cause
+		// a recursion call
+		if err == nil || err == errSerializingHearbeat {
+			return
+		}
+		message := err.Error()
+		progress.ErrorMessage = &message
+		_ = sendSQLTaskProgress(progress, heartbeats)
+	}()
+
+	// initial heartbeat
+	err = sendSQLTaskProgress(progress, heartbeats)
+	if err != nil {
+		return err
+	}
+
+	spec := SQLExecTaskSpec{}
+	err = json.Unmarshal(task.Spec, &spec)
+	if err != nil {
+		return fmt.Errorf("can not parse the sql task spec %w", err)
+	}
+
+	span.SetTag("task.spec.sql", spec.SQL)
+	log.Debug(spec.SQL)
+
+	now := time.Now()
+	result, err := h.db.ExecContext(ctx, spec.SQL)
+	duration := time.Since(now).Milliseconds()
+	progress.Duration = &duration
+
+	if err != nil {
+		return fmt.Errorf("sql execution failed: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("can not get rows affected: %w", err)
+	}
+
+	progress.RowsAffected = &rowsAffected
+	err = sendSQLTaskProgress(progress, heartbeats)
+	if err != nil {
+		return err
+	}
+
+	log.WithField("rowCount", rowsAffected).Debug("finished")
+	return nil
+}
+
+func sendSQLTaskProgress(progress SQLTaskProgress, heartbeats chan<- queue.Progress) (err error) {
+	logrus.
+		WithField("method", "sendSQLTaskProgress").
+		Debugf("%+v", progress)
+
+	bytes, err := json.Marshal(progress)
+	if err != nil {
+		logrus.Error(err)
+		return errSerializingHearbeat
+	}
+
+	heartbeats <- bytes
+	return nil
+}

--- a/pkg/queue/workers/sql_task_test.go
+++ b/pkg/queue/workers/sql_task_test.go
@@ -1,1 +1,0 @@
-package workers

--- a/pkg/queue/workers/sql_task_test.go
+++ b/pkg/queue/workers/sql_task_test.go
@@ -1,0 +1,1 @@
+package workers


### PR DESCRIPTION
**What**
- Create a new task handler that can be used to cleanup old tasks
  matching a specific filter. The caller can specify the queue, task
  type, status, age, and a custom sqlizer.
- Add utility to schedule this new cleanup task once per hour. The exact
  minute is chosen randomly as a basic attempt to spread our the
  workload.
- Improve the db test utility EqualCount to allow passing an error
  message and ars down to the require method inside of it. This allows
  the errors to be more expressive and hopefully easier to read
- Add new db setup utility that uses docker to ensure a db server is
  ready. This is intended as a dev mode only tool which is not left in
  the final committed code, but can be very useful to speedup test
  iteration and debugging.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>