### PR TITLE
Close heartbeats in the sql task handler

### DIFF
--- a/pkg/queue/workers/retention_test.go
+++ b/pkg/queue/workers/retention_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	cdb "github.com/contiamo/go-base/pkg/db"
+	"go.uber.org/goleak"
 
 	"github.com/Masterminds/squirrel"
 	dbtest "github.com/contiamo/go-base/pkg/db/test"
@@ -25,6 +26,8 @@ import (
 var emptyJSON = []byte("{}")
 
 func TestRetentionHandler(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	logrus.SetOutput(ioutil.Discard)
 	defer logrus.SetOutput(os.Stdout)
 
@@ -151,7 +154,6 @@ func TestRetentionHandler(t *testing.T) {
 	// wait a moment for the final heartbeat and then close the channel to avoid
 	// goroutine leak errors
 	time.Sleep(time.Second)
-	close(heartbeats)
 
 	require.Equal(t, SQLTaskProgress{}, seenBeats[0])
 

--- a/pkg/queue/workers/sql_task.go
+++ b/pkg/queue/workers/sql_task.go
@@ -51,6 +51,7 @@ func (h *sqlTaskHandler) Process(ctx context.Context, task queue.Task, heartbeat
 	span, ctx := h.StartSpan(ctx, "Process")
 	defer func() {
 		h.FinishSpan(span, err)
+		close(heartbeats)
 	}()
 	span.SetTag("task.id", task.ID)
 	span.SetTag("task.queue", task.Queue)


### PR DESCRIPTION
**What**
- Ensure that the task actually ends by closing the heartbeats channel.
  This was not seen during previous testing because the test code closed
  the channel. However, when deployed, the task never finished.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>