### PR TITLE
Use INSERT ON CONFLICT for retention task upsert

### DIFF
--- a/pkg/queue/postgres/scheduler.go
+++ b/pkg/queue/postgres/scheduler.go
@@ -175,7 +175,7 @@ func (q *scheduler) AssertSchedule(ctx context.Context, schedule queue.TaskSched
 		PlaceholderFormat(squirrel.Dollar).
 		RunWith(cdb.WrapWithTracing(tx))
 
-	_, err = tx.ExecContext(ctx, `LOCK TABLE schedules IN ACCESS EXCLUSIVE MODE;`)
+	_, err = tx.ExecContext(ctx, `LOCK TABLE schedules IN SHARE MODE;`)
 	if err != nil {
 		return fmt.Errorf("failed to lock `schedules`: %w", err)
 	}

--- a/pkg/queue/postgres/setup_test.go
+++ b/pkg/queue/postgres/setup_test.go
@@ -29,12 +29,18 @@ func TestSetupTables(t *testing.T) {
 		defer db.Close()
 		require.NoError(t, SetupTables(ctx, db, nil))
 
-		//SELECT * FROM pg_class c, pg_namespace n WHERE c.relnamespace = n.oid
-		// AND relname = 'unique_retention_idx' AND relkind = 'i';
-		dbtest.EqualCount(t, db, 1, "pg_class c, pg_namespace n", squirrel.Eq{
-			"relname": "unique_retention_idx",
-			"relkind": "i",
-			"nspname": "public",
+		dbtest.EqualCount(t, db, 1, "pg_indexes", squirrel.And{
+			squirrel.Eq{
+				"indexname": "unique_retention_idx",
+				"tablename": "schedules",
+			},
+			squirrel.Like{"indexdef": "CREATE UNIQUE INDEX%"},
+			squirrel.Like{"indexdef": "%task_queue%"},
+			squirrel.Like{"indexdef": "%task_spec%"},
+			squirrel.Like{"indexdef": "%queueName%"},
+			squirrel.Like{"indexdef": "%taskType%"},
+			squirrel.Like{"indexdef": "%status%"},
+			squirrel.Like{"indexdef": "%WHERE%"},
 		})
 	})
 

--- a/pkg/queue/postgres/setup_test.go
+++ b/pkg/queue/postgres/setup_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/squirrel"
 	dbtest "github.com/contiamo/go-base/v2/pkg/db/test"
 	"github.com/contiamo/go-base/v2/pkg/queue"
 	"github.com/sirupsen/logrus"
@@ -27,6 +28,14 @@ func TestSetupTables(t *testing.T) {
 		_, db := dbtest.GetDatabase(t)
 		defer db.Close()
 		require.NoError(t, SetupTables(ctx, db, nil))
+
+		//SELECT * FROM pg_class c, pg_namespace n WHERE c.relnamespace = n.oid
+		// AND relname = 'unique_retention_idx' AND relkind = 'i';
+		dbtest.EqualCount(t, db, 1, "pg_class c, pg_namespace n", squirrel.Eq{
+			"relname": "unique_retention_idx",
+			"relkind": "i",
+			"nspname": "public",
+		})
 	})
 
 	t.Run("bootstraps with references", func(t *testing.T) {


### PR DESCRIPTION
**What**
- When depeloying some of the apps with the retention policy, we saw the
  startup get stuck during the retention task assertion. Moving a an
  INSERT ON CONFLICT upsert method avoids the table lock and has the
  same effect.
- Add a partial unique index to the schedules table that is required for
  the upsert flow
- Any project using the retention policies will need to add this
  migration to their startup

```sql
CREATE UNIQUE INDEX IF NOT EXISTS unique_retention_idx
ON schedules (task_queue, task_type, (task_spec->>'queueName'), (task_spec->>'taskType'), (task_spec->>'status'))
WHERE task_type = 'retention';
```

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>