### PR TITLE
Enable token issuer customization and add auth method references

### DIFF
--- a/pkg/http/middlewares/authorization/claims.go
+++ b/pkg/http/middlewares/authorization/claims.go
@@ -47,24 +47,26 @@ var (
 // 	AllowedIPs       []string `protobuf:"bytes,13,rep,name=AllowedIPs,json=allowedIPs,proto3" json:"AllowedIPs,omitempty"`
 // 	IsTenantAdmin    bool     `protobuf:"varint,14,opt,name=IsTenantAdmin,json=isTenantAdmin,proto3" json:"IsTenantAdmin,omitempty"`
 // 	AdminRealmIDs    []string `protobuf:"bytes,15,rep,name=AdminRealmIDs,json=adminRealmIDs,proto3" json:"AdminRealmIDs,omitempty"`
+// 	AuthenticationMethodReferences []string `protobuf:"bytes,16,rep,name=AuthenticationMethodReferences,json=amr,proto3" json:"AuthenticationMethodReferences,omitempty"`
 // }
 type Claims struct {
-	ID               string    `json:"id"`
-	IssuedAt         Timestamp `json:"iat"`
-	NotBefore        Timestamp `json:"nbf"`
-	Expires          Timestamp `json:"exp"`
-	Issuer           string    `json:"iss"`
-	UserID           string    `json:"sub"`
-	UserName         string    `json:"name"`
-	TenantID         string    `json:"tenantID"`
-	Email            string    `json:"email"`
-	RealmIDs         []string  `json:"realmIDs"`
-	GroupIDs         []string  `json:"groupIDs"`
-	ResourceTokenIDs []string  `json:"resourceTokenIDs"`
-	AllowedIPs       []string  `json:"allowedIPs"`
-	IsTenantAdmin    bool      `json:"isTenantAdmin"`
-	AdminRealmIDs    []string  `json:"adminRealmIDs"`
-	SourceToken      string    `json:"-"`
+	ID                             string    `json:"id"`
+	IssuedAt                       Timestamp `json:"iat"`
+	NotBefore                      Timestamp `json:"nbf"`
+	Expires                        Timestamp `json:"exp"`
+	Issuer                         string    `json:"iss"`
+	UserID                         string    `json:"sub"`
+	UserName                       string    `json:"name"`
+	TenantID                       string    `json:"tenantID"`
+	Email                          string    `json:"email"`
+	RealmIDs                       []string  `json:"realmIDs"`
+	GroupIDs                       []string  `json:"groupIDs"`
+	ResourceTokenIDs               []string  `json:"resourceTokenIDs"`
+	AllowedIPs                     []string  `json:"allowedIPs"`
+	IsTenantAdmin                  bool      `json:"isTenantAdmin"`
+	AdminRealmIDs                  []string  `json:"adminRealmIDs"`
+	SourceToken                    string    `json:"-"`
+	AuthenticationMethodReferences []string  `json:"amr"`
 }
 
 // Valid tests if the Claims object contains the minimal required information

--- a/pkg/tokens/creator_test.go
+++ b/pkg/tokens/creator_test.go
@@ -20,7 +20,7 @@ func TestTokenCreatorCreateProjectAdmin(t *testing.T) {
 		publicKey, err := cfg.GetPublicKey()
 		require.NoError(t, err)
 
-		tc := NewCreator(privateKey, 0)
+		tc := NewCreator("go-base", privateKey, 0)
 		tokenStr, err := tc.CreateProjectAdmin("project", "background-task")
 		require.NoError(t, err)
 		require.NotEmpty(t, tokenStr)
@@ -30,14 +30,14 @@ func TestTokenCreatorCreateProjectAdmin(t *testing.T) {
 		token, err := jwt.ParseWithClaims(tokenStr, &claims, keyFunc)
 		require.NoError(t, err)
 		require.NotNil(t, token)
-		require.Equal(t, "hub", claims.Issuer)
-		require.Equal(t, "@hub", claims.UserName)
+		require.Equal(t, "go-base", claims.Issuer)
+		require.Equal(t, "@go-base", claims.UserName)
 		require.Equal(t, []string{"project"}, claims.AdminRealmIDs)
 		require.Equal(t, []string{"background-task"}, claims.AuthenticationMethodReferences)
 	})
 
 	t.Run("fails if the private key is empty", func(t *testing.T) {
-		tc := NewCreator(nil, 0)
+		tc := NewCreator("go-base", nil, 0)
 		tokenStr, err := tc.CreateProjectAdmin("project", "background-task")
 		require.Empty(t, tokenStr)
 		require.Error(t, err)


### PR DESCRIPTION
* Now the issuer is not hard-coded as `hub` anymore
* The claims have the new `AuthenticationMethodReferences` to make it
  work with IdP