### PR TITLE
Return after task is handled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
       - image: circleci/postgres:alpine
         environment:
           POSTGRES_PASSWORD: localdev

--- a/pkg/queue/workers/task_worker.go
+++ b/pkg/queue/workers/task_worker.go
@@ -111,10 +111,7 @@ func (w *taskWorker) iteration(ctx context.Context, tracer opentracing.Tracer) (
 			if task == nil {
 				return errors.New("task cannot be nil")
 			}
-			err = w.handleTask(ctx, *task)
-			if err != nil {
-				return err
-			}
+			return  w.handleTask(ctx, *task)
 		}
 	}
 }


### PR DESCRIPTION
**What**
- During the worker iteration, return after the task handler returns.
  This stops the iteration span and allows the worker to start a new
  iteration. This will avoid having multiple task spans inside the same
  iteration span.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>