### PR TITLE
Implement logrus hog to log to spans

### DIFF
--- a/pkg/tracing/logrus.go
+++ b/pkg/tracing/logrus.go
@@ -1,0 +1,45 @@
+package tracing
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"github.com/sirupsen/logrus"
+)
+
+// SpanHook is a logrus Hook to send write logs and their fields to the current span.
+type SpanHook struct {}
+
+// Fire implements the Hook interface
+func (hook *SpanHook) Fire(entry *logrus.Entry) error {
+	if entry == nil {
+		return nil
+	}
+
+	ctx := entry.Context
+	if ctx == nil {
+		return nil
+	}
+
+	span := opentracing.SpanFromContext(ctx)
+	if span == nil {
+		return nil
+	}
+
+	fields := []log.Field{
+		log.String("log.msg", entry.Message),
+	}
+
+	for name, data := range entry.Data {
+		fields = append(fields, log.Object(name, data))
+	}
+
+	span.LogFields(fields...)
+
+
+	return nil
+}
+
+// Levels implements the Hook interface
+func (hook *SpanHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}

--- a/pkg/tracing/logrus_test.go
+++ b/pkg/tracing/logrus_test.go
@@ -1,0 +1,92 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/opentracing/opentracing-go/mocktracer"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpanHook(t *testing.T) {
+
+	opentracing.SetGlobalTracer(mocktracer.New())
+
+	hook := &SpanHook{}
+	ctx := context.Background()
+	span, ctxWithSpan := opentracing.StartSpanFromContext(ctx, "TestSpanHook")
+
+	mockspan, ok := span.(*mocktracer.MockSpan)
+	require.True(t, ok, "must have mock span for a valid test case")
+
+
+	fields := logrus.Fields{
+		"count": 2,
+		"welcome": "hi there",
+	}
+
+	cases := []struct{
+		name string
+		entry *logrus.Entry
+		span *mocktracer.MockSpan
+		err string
+	}{
+		{
+			name: "handles missing context",
+			entry: &logrus.Entry{
+				Message: "test message without context",
+			},
+		},
+		{
+			name: "handles context with no span",
+			entry: &logrus.Entry{
+				Message: "test message without span",
+				Context: context.Background(),
+			},
+		},
+		{
+			name: "handles context with valid span",
+			entry: &logrus.Entry{
+				Message: "test message with tracing",
+				Context: ctxWithSpan,
+				Data: fields,
+			},
+			span: mockspan,
+		},
+	}
+
+	for _, tc := range cases{
+		t.Run(tc.name, func(t *testing.T) {
+			err := hook.Fire(tc.entry)
+			if tc.err != "" {
+				require.EqualError(t, err, tc.err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.span != nil {
+				spanFields := map[string]string{}
+				logs := tc.span.Logs()
+				for _, record := range logs {
+					for _, f := range record.Fields {
+						spanFields[f.Key] = f.ValueString
+					}
+				}
+
+				entryFields := map[string]string{
+					"log.msg": tc.entry.Message,
+				}
+				for name, value := range tc.entry.Data {
+					entryFields[name] = fmt.Sprintf("%v", value)
+				}
+
+				require.Equal(t, entryFields, spanFields, "log fields mismatch")
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
**What**
- Implement `SpanHook` that can write logrus Entries to the current span
  logs. This unifies the log interface in our projects

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>