### PR TITLE
Add tracing ids to log fields via the span hook

### DIFF
--- a/pkg/tracing/logrus_test.go
+++ b/pkg/tracing/logrus_test.go
@@ -69,7 +69,10 @@ func TestSpanHook(t *testing.T) {
 
 			require.NoError(t, err)
 			if tc.span != nil {
-				spanFields := map[string]string{}
+				spanFields := map[string]string{
+					"traceId": fmt.Sprintf("%v",  tc.span.SpanContext.TraceID),
+					"spanId": fmt.Sprintf("%v",  tc.span.SpanContext.SpanID),
+				}
 				logs := tc.span.Logs()
 				for _, record := range logs {
 					for _, f := range record.Fields {


### PR DESCRIPTION
**What**
- During the span hook, we copy the log to the span, this patch also
  copies the span and trace id to the log so that tools like Grafana can
  correlate log lines back to the traces. This works in two steps

  First, configure the span hook during server init

  ```go
  logrus.AddHook(&tracing.SpanHook{})
  ```

  Then, while logging use `logrus.WithContext(ctx)`

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>