### PR TITLE
Implement JSONEq that allows matches on empty string

### DIFF
--- a/pkg/testing/json.go
+++ b/pkg/testing/json.go
@@ -1,0 +1,26 @@
+package testing
+
+import (
+	"github.com/stretchr/testify/require"
+)
+
+type tHelper interface {
+	Helper()
+}
+
+// JSONEq asserts that two JSON strings are equivalent or both empty.
+//
+//  require.JSONEq(t, "", "")
+//  or
+//  require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func JSONEq(t require.TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	// handle empty json
+	if expected == actual && expected == "" {
+		return
+	}
+
+	require.JSONEq(t, expected, actual, msgAndArgs...)
+}

--- a/pkg/testing/json_test.go
+++ b/pkg/testing/json_test.go
@@ -1,0 +1,55 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONEq(t *testing.T) {
+
+	validCases := []struct {
+		name     string
+		expected string
+		got      string
+	}{
+		{"valid on empty strings", "", ""},
+		{"handles simple reordering of keys", `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`},
+	}
+
+	for _, tc := range validCases {
+		t.Run(tc.name, func(t *testing.T) {
+			JSONEq(t, tc.expected, tc.got)
+		})
+	}
+
+	failureCases := []struct {
+		name     string
+		expected string
+		got      string
+	}{
+		{"failure on empty string and non-empty string", "", `{"hello": "world", "foo": "bar"}`},
+		{"handles json mismatch", `{"hello": "world"}`, `{"foo": "bar", "hello": "world"}`},
+	}
+
+	for _, tc := range failureCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt := new(MockT)
+			JSONEq(mt, tc.expected, tc.got)
+
+			require.True(t, mt.Failed, "should fail")
+		})
+	}
+}
+
+type MockT struct {
+	Failed bool
+}
+
+func (t *MockT) FailNow() {
+	t.Failed = true
+}
+
+func (t *MockT) Errorf(format string, args ...interface{}) {
+	_, _ = format, args
+}


### PR DESCRIPTION
**What**
- To simplify some of the tests checks, it can be helpful to allow
  matches on two empty strings, even though neither is valid json.
  Specifically this helps when testing apis that can return errors
  and 204 empty body.

Tests provide 100% lines coverage of the new method
![image](https://user-images.githubusercontent.com/891889/101636199-432d9e80-3a2b-11eb-8f12-bc5b860c3c76.png)


Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>