### PR TITLE
Add `GetPageInfoWithQuery` to make the interface more convenient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/websocket v1.4.0
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
 	github.com/lib/pq v1.1.1
 	github.com/mattn/go-sqlite3 v1.14.2 // indirect
 	github.com/opentracing/opentracing-go v1.1.0


### PR DESCRIPTION
This allows to get page information to an arbitrary query.

Since the new function is now used by the previous one, the existing unit tests fully cover the new behavior.