### PR TITLE
Avvoid time drift issues during cron scheduling

### DIFF
--- a/pkg/queue/postgres/retention.go
+++ b/pkg/queue/postgres/retention.go
@@ -113,7 +113,6 @@ func AssertRetentionScheduleWithSpec(ctx context.Context, db *sql.DB, spec Reten
 				cron_schedule=EXCLUDED.cron_schedule
 		`, now, now)
 
-	// fmt.Println(squirrel.DebugSqlizer(q))
 	res, err := q.ExecContext(ctx)
 	if err != nil {
 		return fmt.Errorf("can not upsert retention schedule: %w", err)

--- a/pkg/queue/workers/schedule_worker.go
+++ b/pkg/queue/workers/schedule_worker.go
@@ -169,7 +169,7 @@ func (w *scheduleWorker) scheduleTask(ctx context.Context) (err error) {
 			"cron_schedule",
 		).
 		From("schedules").
-		Where("next_execution_time <= Now()").
+		Where(squirrel.LtOrEq{"next_execution_time": time.Now()}).
 		OrderBy("next_execution_time").
 		Limit(1).
 		// Skipping locked rows provides an inconsistent view of the data,


### PR DESCRIPTION
**What**
- Do not mix the use of the sql `NOW` and the server `time.Now` when we
  have time sensitive calculations. This specifically avoids issues
  where the server time drifts behind the DB time, it can cause crons to
  be rescheduled immediately because (from the server persepective) they
  are being scheduled too early

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>