### PR TITLE
Refactor tokens Creator interface

### DIFF
--- a/pkg/queue/handlers/api_request.go
+++ b/pkg/queue/handlers/api_request.go
@@ -142,7 +142,7 @@ func (h *apiRequestHandler) Process(ctx context.Context, task queue.Task, heartb
 	}
 
 	if spec.Authorized {
-		token, err := h.tokenCreator.Create("apiRequestTask")
+		token, err := h.tokenCreator.Create("apiRequestTask", tokens.Options{})
 		if err != nil {
 			return err
 		}

--- a/pkg/tokens/creator.go
+++ b/pkg/tokens/creator.go
@@ -35,8 +35,8 @@ type token struct {
 	IsTenantAdmin                  bool     `json:"isTenantAdmin"`
 	AdminRealmIDs                  []string `json:"adminRealmIDs"`
 	AuthenticationMethodReferences []string `json:"amr"`
-	// AuthorizedParty is used to indicate that the requests is authorizing as a
-	// serice request, giving it super-admin privileges to completely any request.
+	// AuthorizedParty is used to indicate that the request is authorizing as a
+	// service request, giving it super-admin privileges to completely any request.
 	// This replaces the "project admin" behavior of the current tokens.
 	AuthorizedParty string `json:"azp"`
 }
@@ -48,7 +48,7 @@ func (token) Valid() error {
 // Options control the value or the generation of the claims in the resulting token.
 // All values are optional and the empty value will be ignored.
 type Options struct {
-	// Audience is name of the service that receives the request. Other
+	// Audience is a name of the service that receives the request. Other
 	// services should not validate tokens intended for other services.
 	Audience string
 	// ProjectID is the UUID string for a project that the token should be

--- a/pkg/tokens/creator_mock.go
+++ b/pkg/tokens/creator_mock.go
@@ -1,16 +1,13 @@
 package tokens
 
+// CreatorMock is a utility function to simplify writing tests that use the Creator
 type CreatorMock struct {
-	Err       error
-	ProjectID string
-	Token     string
+	Err   error
+	Token string
+	Opts  Options
 }
 
-func (m *CreatorMock) CreateProjectAdmin(projectID string, reference string) (string, error) {
-	m.ProjectID = projectID
-	return m.Token, m.Err
-}
-
-func (m *CreatorMock) Create(reference string) (string, error) {
+// Create implements tokens.Creator
+func (m *CreatorMock) Create(reference string, opts Options) (string, error) {
 	return m.Token, m.Err
 }

--- a/pkg/tokens/creator_test.go
+++ b/pkg/tokens/creator_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTokenCreatorCreateProjectAdmin(t *testing.T) {
+func TestTokenCreatorCreate(t *testing.T) {
 	t.Run("creates a valid signed JWT token", func(t *testing.T) {
 		cfg := config.JWT{
 			PrivateKeyPath: "./testdata/idp.key",
@@ -21,7 +21,7 @@ func TestTokenCreatorCreateProjectAdmin(t *testing.T) {
 		require.NoError(t, err)
 
 		tc := NewCreator("go-base", privateKey, 0)
-		tokenStr, err := tc.CreateProjectAdmin("project", "background-task")
+		tokenStr, err := tc.Create("background-task", Options{ProjectID: "project"})
 		require.NoError(t, err)
 		require.NotEmpty(t, tokenStr)
 
@@ -32,13 +32,46 @@ func TestTokenCreatorCreateProjectAdmin(t *testing.T) {
 		require.NotNil(t, token)
 		require.Equal(t, "go-base", claims.Issuer)
 		require.Equal(t, "@go-base", claims.UserName)
+		require.Equal(t, []string{"project"}, claims.RealmIDs)
 		require.Equal(t, []string{"project"}, claims.AdminRealmIDs)
 		require.Equal(t, []string{"background-task"}, claims.AuthenticationMethodReferences)
+		require.Equal(t, "go-base", claims.AuthorizedParty)
+		require.Equal(t, "", claims.Audience)
+	})
+
+	t.Run("creates a valid signed JWT token with audience", func(t *testing.T) {
+		cfg := config.JWT{
+			PrivateKeyPath: "./testdata/idp.key",
+			PublicKeyPath:  "./testdata/idp.crt",
+		}
+
+		privateKey, err := cfg.GetPrivateKey()
+		require.NoError(t, err)
+		publicKey, err := cfg.GetPublicKey()
+		require.NoError(t, err)
+
+		tc := NewCreator("go-base", privateKey, 0)
+		tokenStr, err := tc.Create("background-task", Options{Audience: "hub"})
+		require.NoError(t, err)
+		require.NotEmpty(t, tokenStr)
+
+		keyFunc := func(*jwt.Token) (interface{}, error) { return publicKey, nil }
+		var claims token
+		token, err := jwt.ParseWithClaims(tokenStr, &claims, keyFunc)
+		require.NoError(t, err)
+		require.NotNil(t, token)
+		require.Equal(t, "go-base", claims.Issuer)
+		require.Equal(t, "@go-base", claims.UserName)
+		require.Equal(t, []string{}, claims.RealmIDs)
+		require.Equal(t, []string{}, claims.AdminRealmIDs)
+		require.Equal(t, []string{"background-task"}, claims.AuthenticationMethodReferences)
+		require.Equal(t, "go-base", claims.AuthorizedParty)
+		require.Equal(t, "hub", claims.Audience)
 	})
 
 	t.Run("fails if the private key is empty", func(t *testing.T) {
 		tc := NewCreator("go-base", nil, 0)
-		tokenStr, err := tc.CreateProjectAdmin("project", "background-task")
+		tokenStr, err := tc.Create("background-task", Options{ProjectID: "project"})
 		require.Empty(t, tokenStr)
 		require.Error(t, err)
 		require.Equal(t, ErrNoPrivateKeySpecified.Error(), err.Error())


### PR DESCRIPTION
**What**
- Refactor the creator interface to always geneate inter-service tokens.
- Add the `aud` field (Audience) to the token claims
- Add the `azp` field (AuthorizedParty) to the token claims
- Pass the project and the audiance via a new `tokens.Options` struct,
  this makes it easier to update the interface in the future.
- This allows us to avoid re-using authorization concepts like the
  project admin when communicating between services, we can now be more
  explicit that the request represents a specific service via the `azp`
  value.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>