### PR TITLE
feat: Suppor ozzo v4 validation errors in the base handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/getkin/kin-openapi v0.14.0
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
+	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/golang/protobuf v1.5.1
 	github.com/gorilla/websocket v1.4.2
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
@@ -95,6 +96,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-ozzo/ozzo-validation v3.6.0+incompatible h1:msy24VGS42fKO9K1vLz82/GeYW1cILu7Nuuj1N3BBkE=
 github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
+github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead57VkAEY4V+Es=
+github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=

--- a/pkg/http/handlers/base_test.go
+++ b/pkg/http/handlers/base_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	validationV1 "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pkg/errors"
 
 	cerrors "github.com/contiamo/go-base/v3/pkg/errors"
@@ -118,6 +120,27 @@ func TestError(t *testing.T) {
 		{
 			name:      "Returns 422 and field errors when validation errors",
 			err:       cerrors.ValidationErrors{"field": errors.New("terrible")},
+			expStatus: http.StatusUnprocessableEntity,
+			expBody: `{"errors":[{"type":"FieldError","message":"terrible","key":"field"}]}
+`,
+		},
+		{
+			name:      "Returns 422 and field errors when validation errors",
+			err:       validation.Errors{"field": errors.New("terrible")},
+			expStatus: http.StatusUnprocessableEntity,
+			expBody: `{"errors":[{"type":"FieldError","message":"terrible","key":"field"}]}
+`,
+		},
+		{
+			name:      "Returns 422 and field errors when validation errors",
+			err:       validation.Errors{"field": errors.New("terrible")},
+			expStatus: http.StatusUnprocessableEntity,
+			expBody: `{"errors":[{"type":"FieldError","message":"terrible","key":"field"}]}
+`,
+		},
+		{
+			name:      "Returns 422 and field errors when validation errors",
+			err:       validationV1.Errors{"field": errors.New("terrible")},
 			expStatus: http.StatusUnprocessableEntity,
 			expBody: `{"errors":[{"type":"FieldError","message":"terrible","key":"field"}]}
 `,


### PR DESCRIPTION
- Allow the base http handler to handle validation errors
  from ozzo v1 and ozzo v4. The new v4 handling allows the
  base handler to support the generated validators from
  openapi-generator-go:
  https://github.com/contiamo/openapi-generator-go


I needed this as part of the upgrade to the new generator in datastore, some of the handlers were returning 500s where it was previously returning 422, with this change, they return 422 again.