### PR TITLE
fix: during authn errors print req object as string

### DIFF
--- a/pkg/http/middlewares/authorization/middleware.go
+++ b/pkg/http/middlewares/authorization/middleware.go
@@ -49,7 +49,7 @@ func (a *middleware) WrapHandler(next http.Handler) http.Handler {
 				// the data sent via the request body
 				prettyRequest, _ := httputil.DumpRequest(r, false)
 				logrus.WithError(err).
-					WithField("request", prettyRequest).
+					WithField("request", string(prettyRequest)).
 					Debugf("incoming request")
 			}
 			a.FinishSpan(span, err)


### PR DESCRIPTION
**What**
- When the logging was previously refactored in the authorization
  middleware, the `prettyRequest` was being logged as a raw bytes
  array, which is impossible to read. This change converts it to a
  string so that the log is readable.

Found while testing CON-3026

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>