### PR TITLE
fix: Add more logging during db migrations

### DIFF
--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -82,12 +82,17 @@ func migrate(ctx context.Context, db *sql.DB, list []string, assets http.FileSys
 			continue
 		}
 
-		_, err = tx.ExecContext(ctx, stmt)
+		res, err := tx.ExecContext(ctx, stmt)
 		if err != nil {
 			logger.WithError(err).Error("migration failed")
 			return errors.Wrap(err, "migration failed")
 		}
-		logger.Info("migration finished")
+		affected, err := res.RowsAffected()
+		if err != nil {
+			logger.WithError(err).Error("can't count affected rows")
+			return errors.Wrap(err, "can't count affected rows")
+		}
+		logger.WithField("affected", affected).Info("migration finished")
 	}
 
 	return err


### PR DESCRIPTION
**What**
- Add more logging so that users can see the run or skip message for all
  migration statements. Additionally, add a few more log statements to
  ensure all possible errors are logged as soon as possible

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>