### PR TITLE
fix: Use named return to ensure migration commit err is returned

### DIFF
--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -18,7 +18,7 @@ func NewMigrater(stmts []string, assets http.FileSystem) func(context.Context, *
 	}
 }
 
-func migrate(ctx context.Context, db *sql.DB, list []string, assets http.FileSystem) error {
+func migrate(ctx context.Context, db *sql.DB, list []string, assets http.FileSystem) (err error) {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		logrus.Errorf("failed to start migration transaction: %v", err)


### PR DESCRIPTION
Use a named return in the `migrate` method so that the error from
`err = tx.Commit()` is correctly ghosting the return value and therefore
actually returned to the calling method

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>