### PR TITLE
fix: Do not throw errors for idle transactions during migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ setup-env: $(GIT_SEMVER) $(GOLANGCI_LINT) ## Setup dev environment
 
 .PHONY: .test-ci
 .test-ci:
-	go test -v -cover ./...
+	go test -cover ./...
 
 .PHONY: changelog
 changelog: ## Print git hitstory based changelog


### PR DESCRIPTION
Catch and ignore `pq: unexpected transaction status idle` errors when we
commit the migrations transaction.  We have not see the error in
practice when testing the recent changes to the migrations _but_ we do
see this in the unit tests for Hub. This error indicates that a
transaction has started, ie `BEGIN;` but that nothing has happened in
the transaction yet. A similar (but resolved) issue happened in the pq
driver, but the culprit (unclosed Rows) does not apply to our method,
all possible Row objects are automatically closed for us by the sql
methods. See https://github.com/lib/pq/issues/225

See also
https://www.postgresql.org/message-id/20080617133250.GA68434@commandprompt.com

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>