### PR TITLE
ci: Automate release workflow

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,24 @@
+
+
+name: 'Conventional commit titles'
+on:
+  pull_request:
+    types:
+      # Check title when opened.
+      - opened
+      # Check title when new commits are pushed.
+      # Required to use as a status check.
+      - synchronize
+      # When the title or description change
+      - edited
+
+jobs:
+  publish:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          # Ensure pull request titles match the Conventional Commits specification https://www.conventionalcommits.org/en/v1.0.0/
+          # The optional scope is for a Jira ticket number (`CON-xxxx`)
+          regex: '^(feat|fix|chore|ci|refactor|test)(\(CON-\d+\))?!?:'

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches:
+      - master
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: go-yoshi
+          package-name: go-base


### PR DESCRIPTION
**What**
- Add workflow that enfoces conventional commits on our PR titles
- Add workflow that automates creating releases. It opens a PR with
the new changelog. The PR will be kept up-to-date as more merges
happen.  When merged a tag/release is automatically created.
- Remove release changelog management from jenkins

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>