### PR TITLE
ci: fix dependabot config to support conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,13 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/Berlin"
+    commit-message:
+      prefix: "chore"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/Berlin"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
ci: add github-actions to dependabot


Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>