### PR TITLE
feat: Add error handling for Unsupported Media Type

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -33,7 +33,7 @@ var (
 	// nolint: stylecheck // this a special error that is displayed to the user as it is.
 	ErrNotImplemented = errors.New("Method is not implemented")
 	// ErrUnsupportedMediaType is intended to be used for endpoints that accepts multiple
-	// media types and need to return the standard "415 Unsupported Media Type" reposne
+	// media types and need to return the standard "415 Unsupported Media Type" response
 	// nolint: stylecheck // this a special error that is displayed to the user as it is.
 	ErrUnsupportedMediaType = errors.New("Unsupported Media Type")
 )

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -32,6 +32,10 @@ var (
 	// ErrNotImplemented is intended to be used when stubbing new endpoints
 	// nolint: stylecheck // this a special error that is displayed to the user as it is.
 	ErrNotImplemented = errors.New("Method is not implemented")
+	// ErrUnsupportedMediaType is intended to be used for endpoints that accepts multiple
+	// media types and need to return the standard "415 Unsupported Media Type" reposne
+	// nolint: stylecheck // this a special error that is displayed to the user as it is.
+	ErrUnsupportedMediaType = errors.New("Unsupported Media Type")
 )
 
 // ValidationErrors contains errors organized by validated fields

--- a/pkg/http/handlers/base.go
+++ b/pkg/http/handlers/base.go
@@ -105,6 +105,9 @@ func (h *baseHandler) Error(ctx context.Context, w http.ResponseWriter, err erro
 	case cerrors.ErrInvalidParameters:
 		h.Write(ctx, w, http.StatusBadRequest, genErrResp)
 		return
+	case cerrors.ErrUnsupportedMediaType:
+		h.Write(ctx, w, http.StatusUnsupportedMediaType, genErrResp)
+		return
 	case cerrors.ErrNotImplemented:
 		h.Write(ctx, w, http.StatusNotImplemented, genErrResp)
 		return


### PR DESCRIPTION
Add a new error `ErrUnsupportedMediaType` and handling for this error in
the BaseHandler implementation. This allows for endpoints that support
multiple content types to test and return an appropriate standard
response if the request is not supported.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>