### PR TITLE
fix: make API errors more informative, no empty strings

### DIFF
--- a/pkg/http/clients/base_api_client.go
+++ b/pkg/http/clients/base_api_client.go
@@ -18,21 +18,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// APIError describes an error during unsuccessful HTTP request to an API
-type APIError struct {
-	// Status is the HTTP status of the API response
-	Status int
-	// Header is the set of response headers
-	Header http.Header
-	// Response is the response body
-	Response []byte
-}
-
-// Error implements the error interface
-func (e APIError) Error() string {
-	return http.StatusText(e.Status)
-}
-
 // TokenProvider is a function that gets the token string for each request
 type TokenProvider func() (token string, err error)
 

--- a/pkg/http/clients/errors.go
+++ b/pkg/http/clients/errors.go
@@ -1,0 +1,111 @@
+package clients
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	cerrors "github.com/contiamo/go-base/v3/pkg/errors"
+)
+
+type errorResponse struct {
+	Errors []respError `json:"errors"`
+}
+type respError struct {
+	Key     string `json:"key"`
+	Message string `json:"message"`
+}
+
+// APIError describes an error during unsuccessful HTTP request to an API
+type APIError struct {
+	// Status is the HTTP status of the API response
+	Status int
+	// Header is the set of response headers
+	Header http.Header
+	// Response is the bytes of the response body
+	Response []byte
+}
+
+// Error implements the error interface.
+// Builds a complete error message out of all the errors served in the API response.
+// This should be used in logging, tracing, debugging, etc.
+// For user facing errors use `ValidationErrors` function.
+func (e APIError) Error() (message string) {
+	errs := e.ResponseErrors()
+
+	messages := make([]string, 0, len(errs)+1) // plus the status message in the beginning
+
+	status := http.StatusText(e.Status)
+	if status == "" {
+		status = strconv.Itoa(e.Status)
+	}
+	messages = append(messages, status)
+
+	for _, err := range errs {
+		messages = append(messages, err.Error())
+	}
+
+	return strings.Join(messages, "; ")
+}
+
+// ValidationErrors returns a map of validation errors in case they were present in response errors.
+// Otherwise, returns `nil` if there were no validation errors in the response.
+func (e APIError) ValidationErrors() (errs cerrors.ValidationErrors) {
+	allErrs := e.ResponseErrors()
+
+	// it's always not more than one `cerrors.ValidationErrors` on the list
+	for _, err := range allErrs {
+		switch typed := err.(type) {
+		case cerrors.ValidationErrors:
+			return typed
+		}
+	}
+	return nil
+}
+
+// ResponseErrors returns a slice of all errors that  were present in the API response.
+// All the field errors are folded into a single validation error map.
+// All the general errors are mapped to regular errors.
+// Returns `nil` if the response contained no errors in the expected JSON format.
+// For the 522 status code it handles a special case where all the general errors become validation
+// errors for the `connection` field.
+func (e APIError) ResponseErrors() (errs []error) {
+	var response errorResponse
+	err := json.Unmarshal(e.Response, &response)
+	if err != nil {
+		return nil
+	}
+
+	validationErrs := make(cerrors.ValidationErrors, len(response.Errors))
+	connectivityGeneralErrs := make([]string, 0, len(response.Errors))
+
+	for _, respErr := range response.Errors {
+		if respErr.Key != "" {
+			validationErrs[respErr.Key] = errors.New(respErr.Message)
+			continue
+		}
+
+		// special case for connectivity errors that should be turned into validation errors
+		if e.Status == 522 {
+			connectivityGeneralErrs = append(connectivityGeneralErrs, respErr.Message)
+			continue
+		}
+
+		errs = append(errs, errors.New(respErr.Message))
+	}
+
+	if len(connectivityGeneralErrs) > 0 {
+		if validationErrs["connection"] != nil {
+			connectivityGeneralErrs = append(connectivityGeneralErrs, validationErrs["connection"].Error())
+		}
+		validationErrs["connection"] = errors.New(strings.Join(connectivityGeneralErrs, ". "))
+	}
+
+	if len(validationErrs) > 0 {
+		errs = append(errs, validationErrs)
+	}
+
+	return errs
+}

--- a/pkg/http/clients/errors_test.go
+++ b/pkg/http/clients/errors_test.go
@@ -1,0 +1,113 @@
+package clients
+
+import (
+	"net/http"
+	"testing"
+
+	ctesting "github.com/contiamo/go-base/v3/pkg/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIErrorError(t *testing.T) {
+	cases := []struct {
+		name       string
+		e          APIError
+		expMessage string
+	}{
+		{
+			name: "Returns status text and no errors",
+			e: APIError{
+				Status: http.StatusBadRequest,
+			},
+			expMessage: http.StatusText(http.StatusBadRequest),
+		},
+		{
+			name: "Returns status code if it's not standard",
+			e: APIError{
+				Status: 522,
+			},
+			expMessage: "522",
+		},
+		{
+			name: "Returns status text and errors",
+			e: APIError{
+				Status: http.StatusBadRequest,
+				Response: ctesting.ToJSONBytes(t, map[string]interface{}{
+					"errors": []map[string]string{
+						{
+							"message": "general error message",
+						},
+						{
+							"message": "second general error message",
+						},
+						{
+							"key":     "field1",
+							"message": "field1 is wrong",
+						},
+						{
+							"key":     "field2",
+							"message": "field2 is wrong",
+						},
+					},
+				}),
+			},
+			expMessage: "Bad Request; general error message; second general error message; field1: field1 is wrong; field2: field2 is wrong.",
+		},
+		{
+			name: "Returns 522 and errors including the special connectivity errors",
+			e: APIError{
+				Status: 522,
+				Response: ctesting.ToJSONBytes(t, map[string]interface{}{
+					"errors": []map[string]string{
+						{
+							"message": "general error message",
+						},
+						{
+							"message": "second general error message",
+						},
+						{
+							"key":     "field1",
+							"message": "field1 is wrong",
+						},
+						{
+							"key":     "field2",
+							"message": "field2 is wrong",
+						},
+					},
+				}),
+			},
+			expMessage: "522; connection: general error message. second general error message; field1: field1 is wrong; field2: field2 is wrong.",
+		},
+		{
+			name: "Returns 522 and concatenates connectivity errors",
+			e: APIError{
+				Status: 522,
+				Response: ctesting.ToJSONBytes(t, map[string]interface{}{
+					"errors": []map[string]string{
+						{
+							"message": "first connection issue",
+						},
+						{
+							"message": "second connection issue",
+						},
+						{
+							"key":     "connection",
+							"message": "another connection issue",
+						},
+						{
+							"key":     "field1",
+							"message": "field1 is wrong",
+						},
+					},
+				}),
+			},
+			expMessage: "522; connection: first connection issue. second connection issue. another connection issue; field1: field1 is wrong.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expMessage, tc.e.Error())
+		})
+	}
+}


### PR DESCRIPTION
No the `APIError` struct implements all the edge cases of error
reporting and simplifies how we handle error responses.