### PR TITLE
fix: do not parse body if ouput dest is nil

### DIFF
--- a/pkg/http/clients/base_api_client.go
+++ b/pkg/http/clients/base_api_client.go
@@ -159,9 +159,10 @@ func (t baseAPIClient) DoRequest(ctx context.Context, method, path string, query
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		contentType := resp.Header.Get("content-type")
 		contentType = strings.ToLower(contentType)
+		span.SetTag("response_has_output_destination", out != nil)
 		span.SetTag("resp.contentType", contentType)
 
-		if strings.Contains(contentType, "json") {
+		if out != nil && strings.Contains(contentType, "json") {
 			decoder := json.NewDecoder(resp.Body)
 			return errors.Wrap(decoder.Decode(out), "failed to decode JSON response")
 		}

--- a/pkg/http/clients/base_api_client_test.go
+++ b/pkg/http/clients/base_api_client_test.go
@@ -110,16 +110,29 @@ func TestBaseAPIClientDoRequest(t *testing.T) {
 			},
 		},
 		{
-			name:   "Posts nothing, gets nothing with 204",
+			name:   "Ignores response body when the out value is nil",
 			method: http.MethodPost,
 			path:   "/some/path",
-			out:    &out,
+			out:    nil,
+
+			token: "tokenSample",
+
+			serverStatus:   http.StatusOK,
+			serverResponse: ctesting.ToJSONBytes(t, resp),
+
+			expResponse: nil,
+		},
+		{
+			name:   "Posts nothing, gets nothing with 204 and parsing nothing into nil",
+			method: http.MethodPost,
+			path:   "/some/path",
+			out:    nil,
 
 			token: "tokenSample",
 
 			serverStatus: http.StatusNoContent,
 
-			expResponse: &response{},
+			expResponse: nil,
 		},
 		{
 			name:   "Gets response with 200",


### PR DESCRIPTION
When an JSON api responses with 204 No Content, the BaseAPIClient
implementation would still attempt to parse the response body. But this
just throws and EOF error. When the API is responding with 204 this is
actually expected and the caller should/will pass a `nil` value to the
`out` parameter. The client implementation will now skip parsing the
body if the `out` destination is nil.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>