### PR TITLE
feat(CON-3568): check that ids exist under a filter when resolving.

### DIFF
--- a/pkg/data/managers/id_resolver_test.go
+++ b/pkg/data/managers/id_resolver_test.go
@@ -119,6 +119,14 @@ func Test_Resolve(t *testing.T) {
 			expErr: true,
 		},
 		{
+			name:  "Triggers error when resolve a id with a wrong parent_id filter",
+			value: ids[1].String(),
+			where: squirrel.Eq{
+				"parent_id": secIDs[1],
+			},
+			expErr: true,
+		},
+		{
 			name:       "Triggers error when there are more than one result",
 			value:      "regular",
 			expectedID: "",


### PR DESCRIPTION
Before this change we would accept any valid UUID in the id resolver without database interaction. This caused CON-3568 where its possible to retrieve a table by id using a URL with a wrong data source id.

Now the resolver actually looks up the id, if its a valid uuid, under the given filter, so we return an error when the id is not actually found in the database. 