### PR TITLE
fix: sort field errors not only by message, but by key (if any) and then by message

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -73,8 +73,8 @@ func ValidationErrorsToFieldErrorResponse(errs ValidationErrors) (resp ErrorResp
 	sort.Slice(resp.Errors, func(i, j int) bool {
 		e1, ok1 := resp.Errors[i].(interface{ GetKey() string })
 		e2, ok2 := resp.Errors[j].(interface{ GetKey() string })
-		if ok1 && ok2 && e1.GetKey() < e2.GetKey() {
-			return true
+		if ok1 && ok2 {
+			return e1.GetKey() < e2.GetKey()
 		}
 		return resp.Errors[i].GetMessage() < resp.Errors[j].GetMessage()
 	})

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -71,6 +71,11 @@ func ValidationErrorsToFieldErrorResponse(errs ValidationErrors) (resp ErrorResp
 
 	// to always have deterministic results
 	sort.Slice(resp.Errors, func(i, j int) bool {
+		e1, ok1 := resp.Errors[i].(interface{ GetKey() string })
+		e2, ok2 := resp.Errors[j].(interface{ GetKey() string })
+		if ok1 && ok2 && e1.GetKey() < e2.GetKey() {
+			return true
+		}
 		return resp.Errors[i].GetMessage() < resp.Errors[j].GetMessage()
 	})
 	return resp

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -66,6 +66,31 @@ func TestValidationErrorsToErrorResponse(t *testing.T) {
 			},
 		},
 		{
+			name: "Does sort by key",
+			errs: ValidationErrors{
+				"b": errors.New("bad field b"),
+				"a": errors.New("bad field a"),
+			},
+			expected: ErrorResponse{
+				Errors: []APIErrorMessenger{
+					FieldError{
+						GeneralError: GeneralError{
+							Type:    FieldErrorType,
+							Message: "bad field a",
+						},
+						Key: "a",
+					},
+					FieldError{
+						GeneralError: GeneralError{
+							Type:    FieldErrorType,
+							Message: "bad field b",
+						},
+						Key: "b",
+					},
+				},
+			},
+		},
+		{
 			name: "empty string keys are mapped to a GeneralError type",
 			errs: ValidationErrors{
 				"field1": errors.New("bad field1"),


### PR DESCRIPTION
Before this change the sorting of the field errors was not deterministic because we only sorted by message. So if you have for example an error with two wrong enums, you get the same message but different keys. Now the order of those two errors is unfortunatly random. 

Now I look if the errors have a GetKey() function and if they have I use it for sorting, if not I fallback to the message.