### PR TITLE
fix: add missing GetKey() function for FieldErrors.

### DIFF
--- a/pkg/errors/error_response.go
+++ b/pkg/errors/error_response.go
@@ -40,6 +40,10 @@ func (e FieldError) GetMessage() string {
 	return e.Message
 }
 
+func (e FieldError) GetKey() string {
+	return e.Key
+}
+
 // Scrubbed implemented the APIErrorMessanger, the scrubbing
 // is a noop because FieldError is safe for users by default.
 func (e FieldError) Scrubbed(_ string) APIErrorMessenger {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -25,22 +25,22 @@ func TestValidationErrorsToErrorResponse(t *testing.T) {
 		{
 			name: "Returns errors in the response when errors are not empty",
 			errs: ValidationErrors{
-				"field1": errors.New("bad field1"),
-				"field2": errors.New("bad field2"),
+				"field1": errors.New("error message"),
+				"field2": errors.New("error message"),
 			},
 			expected: ErrorResponse{
 				Errors: []APIErrorMessenger{
 					FieldError{
 						GeneralError: GeneralError{
 							Type:    FieldErrorType,
-							Message: "bad field1",
+							Message: "error message",
 						},
 						Key: "field1",
 					},
 					FieldError{
 						GeneralError: GeneralError{
 							Type:    FieldErrorType,
-							Message: "bad field2",
+							Message: "error message",
 						},
 						Key: "field2",
 					},


### PR DESCRIPTION
I thought that the FieldError type comes from our generator, because it already had getters for Type and Message. This was wrong so I was expecting that GetKey() also exists, but in fact it doesn't. 

This commit now adds the GetKey() method, so that the key is correctly picked up when sorting.

I adjusted the unit test so that both error messages are the same, so that it really would be non-deterministic if not sorted by key.