### PR TITLE
fix: upgrade JWT library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/contiamo/goserver v0.5.2
 	github.com/contiamo/jwt v0.2.2
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.0.0 // indirect
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/pkg/config/jwt.go
+++ b/pkg/config/jwt.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rsa"
 	"io/ioutil"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/config/jwt_test.go
+++ b/pkg/config/jwt_test.go
@@ -19,7 +19,7 @@ func TestJWTGetPublicKey(t *testing.T) {
 		key, err := cfg.GetPublicKey()
 		require.Nil(t, key)
 		require.Error(t, err)
-		require.Equal(t, "Invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key", err.Error())
+		require.Equal(t, "Invalid Key: Key must be a PEM encoded PKCS1 or PKCS8 key", err.Error())
 	})
 	t.Run("Returns error when the path is not found", func(t *testing.T) {
 		cfg := JWT{PublicKeyPath: "./testdata/invalid"}
@@ -50,7 +50,7 @@ func TestJWTGetPrivateKey(t *testing.T) {
 		key, err := cfg.GetPrivateKey()
 		require.Nil(t, key)
 		require.Error(t, err)
-		require.Equal(t, "Invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key", err.Error())
+		require.Equal(t, "Invalid Key: Key must be a PEM encoded PKCS1 or PKCS8 key", err.Error())
 	})
 	t.Run("Returns error when the path is not found", func(t *testing.T) {
 		cfg := JWT{PrivateKeyPath: "./testdata/invalid"}

--- a/pkg/http/middlewares/authorization/middleware.go
+++ b/pkg/http/middlewares/authorization/middleware.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/contiamo/go-base/v4/pkg/tracing"
 	goserverhttp "github.com/contiamo/goserver/http"
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/http/middlewares/authorization/middleware_test.go
+++ b/pkg/http/middlewares/authorization/middleware_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/tokens/creator.go
+++ b/pkg/tokens/creator.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	authz "github.com/contiamo/go-base/v4/pkg/http/middlewares/authorization"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	uuid "github.com/satori/go.uuid"
 )

--- a/pkg/tokens/creator_test.go
+++ b/pkg/tokens/creator_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/contiamo/go-base/v4/pkg/config"
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Move from github.com/dgrijalva/jwt-go to github.com/golang-jwt/jwt. The
owner decided to move the development into a separate org and to invite
more maintainers. This version bump also includes a high severity
security fix for https://github.com/contiamo/go-base/security/dependabot/go.mod/github.com%2Fdgrijalva%2Fjwt-go/open

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>