### PR TITLE
feat: use pg_advisory_lock to control db migration concurrency

### DIFF
--- a/pkg/db/migrations/base.go
+++ b/pkg/db/migrations/base.go
@@ -16,8 +16,9 @@ import (
 type sqlKind string
 
 const (
-	migrations sqlKind = "migrations"
-	views      sqlKind = "views"
+	migrations         sqlKind = "migrations"
+	views              sqlKind = "views"
+	idleTransactionErr         = "pq: unexpected transaction status idle"
 )
 
 func getSQL(name string, kind sqlKind, assets http.FileSystem) (string, error) {
@@ -54,7 +55,7 @@ func runStatement(ctx context.Context, db *sql.DB, stmt string) error {
 			//    https://github.com/lib/pq/issues/225
 			// Initial experiments have only produced this during unit tests, but actual
 			// application environments run without any transaction issues.
-			if err != nil && err.Error() == "pq: unexpected transaction status idle" {
+			if err != nil && err.Error() == idleTransactionErr {
 				logger.WithError(err).Warn("idle transaction at Commit")
 				err = nil
 			}

--- a/pkg/db/migrations/base.go
+++ b/pkg/db/migrations/base.go
@@ -1,6 +1,8 @@
 package migrations
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -27,4 +29,17 @@ func getSQL(name string, kind sqlKind, assets http.FileSystem) (string, error) {
 	}
 
 	return string(s), nil
+}
+
+// Lock to ensure multiple migrations cannot occur simultaneously
+const lockNum = int64(47831730) // arbitrary random number
+
+func acquireAdvisoryLock(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, "select pg_advisory_lock($1)", lockNum)
+	return err
+}
+
+func releaseAdvisoryLock(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, "select pg_advisory_unlock($1)", lockNum)
+	return err
 }

--- a/pkg/db/migrations/init.go
+++ b/pkg/db/migrations/init.go
@@ -43,7 +43,7 @@ func initialize(ctx context.Context, db *sql.DB, assets http.FileSystem, queueCo
 		return fmt.Errorf("can not read init statement: %w", err)
 	}
 
-	_, err = db.ExecContext(ctx, stmt)
+	err = runStatement(ctx, db, stmt)
 	if err != nil {
 		return fmt.Errorf("init execution failed: %w", err)
 	}

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -19,6 +19,44 @@ func NewMigrater(stmts []string, assets http.FileSystem) func(context.Context, *
 }
 
 func migrate(ctx context.Context, db *sql.DB, list []string, assets http.FileSystem) (err error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		logrus.Errorf("failed to start migration transaction: %v", err)
+		return err
+	}
+
+	logger := logrus.WithField("method", "migrate")
+
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			// dirty ugly no-good hack!
+			// we have not seen this in the wild yet, _but_ during our unit tests
+			// we sometimes get this error, which indicates that the transaction  was
+			// started (ie `BEGIN;`) but nothing has happened yet. For example:
+			//    https://www.postgresql.org/message-id/20080617133250.GA68434@commandprompt.com
+			//    https://github.com/lib/pq/issues/225
+			// Initial experiments have only produced this during unit tests, but actual
+			// application environments run without any transaction issues.
+			if err != nil && err.Error() == "pq: unexpected transaction status idle" {
+				logger.WithError(err).Warn("idle transaction at Commit")
+				err = nil
+			}
+			if err != nil {
+				logger.WithError(err).Error("can not commit migrations transaction")
+			}
+			return
+		}
+
+		logger.WithError(err).Error("migration transaction requires rollback")
+
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			err = errors.Wrap(err, rollbackErr.Error())
+			logger.WithError(err).Error("migration rollback failed")
+		}
+	}()
+
 	for _, stmtName := range list {
 		logger := logrus.
 			WithField("method", "migrate").
@@ -55,66 +93,18 @@ func migrate(ctx context.Context, db *sql.DB, list []string, assets http.FileSys
 			continue
 		}
 
-		err = runStatement(ctx, db, stmt)
+		res, err := tx.ExecContext(ctx, stmt)
 		if err != nil {
-			return err
+			logger.WithError(err).Error("migration failed")
+			return errors.Wrap(err, "migration failed")
 		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			logger.WithError(err).Error("can't count affected rows")
+			return errors.Wrap(err, "can't count affected rows")
+		}
+		logger.WithField("affected", affected).Info("migration finished")
 	}
 
 	return err
-}
-
-func runStatement(ctx context.Context, db *sql.DB, stmt string) error {
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		logrus.Errorf("failed to start migration transaction: %v", err)
-		return err
-	}
-
-	logger := logrus.WithField("method", "runStatement")
-
-	defer func() {
-		if err == nil {
-			err = tx.Commit()
-			// dirty ugly no-good hack!
-			// we have not seen this in the wild yet, _but_ during our unit tests
-			// we sometimes get this error, which indicates that the transaction  was
-			// started (ie `BEGIN;`) but nothing has happened yet. For example:
-			//    https://www.postgresql.org/message-id/20080617133250.GA68434@commandprompt.com
-			//    https://github.com/lib/pq/issues/225
-			// Initial experiments have only produced this during unit tests, but actual
-			// application environments run without any transaction issues.
-			if err != nil && err.Error() == "pq: unexpected transaction status idle" {
-				logger.WithError(err).Warn("idle transaction at Commit")
-				err = nil
-			}
-			if err != nil {
-				logger.WithError(err).Error("can not commit migrations transaction")
-			}
-			return
-		}
-
-		logger.WithError(err).Error("migration transaction requires rollback")
-
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			err = errors.Wrap(err, rollbackErr.Error())
-			logger.WithError(err).Error("migration rollback failed")
-		}
-	}()
-
-	res, err := tx.ExecContext(ctx, stmt)
-	if err != nil {
-		logger.WithError(err).Error("migration failed")
-		return errors.Wrap(err, "migration failed")
-	}
-
-	affected, err := res.RowsAffected()
-	if err != nil {
-		logger.WithError(err).Error("can't count affected rows")
-		return errors.Wrap(err, "can't count affected rows")
-	}
-	logger.WithField("affected", affected).Info("migration finished")
-
-	return nil
 }

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -19,44 +19,6 @@ func NewMigrater(stmts []string, assets http.FileSystem) func(context.Context, *
 }
 
 func migrate(ctx context.Context, db *sql.DB, list []string, assets http.FileSystem) (err error) {
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		logrus.Errorf("failed to start migration transaction: %v", err)
-		return err
-	}
-
-	logger := logrus.WithField("method", "migrate")
-
-	defer func() {
-		if err == nil {
-			err = tx.Commit()
-			// dirty ugly no-good hack!
-			// we have not seen this in the wild yet, _but_ during our unit tests
-			// we sometimes get this error, which indicates that the transaction  was
-			// started (ie `BEGIN;`) but nothing has happened yet. For example:
-			//    https://www.postgresql.org/message-id/20080617133250.GA68434@commandprompt.com
-			//    https://github.com/lib/pq/issues/225
-			// Initial experiments have only produced this during unit tests, but actual
-			// application environments run without any transaction issues.
-			if err != nil && err.Error() == "pq: unexpected transaction status idle" {
-				logger.WithError(err).Warn("idle transaction at Commit")
-				err = nil
-			}
-			if err != nil {
-				logger.WithError(err).Error("can not commit migrations transaction")
-			}
-			return
-		}
-
-		logger.WithError(err).Error("migration transaction requires rollback")
-
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil {
-			err = errors.Wrap(err, rollbackErr.Error())
-			logger.WithError(err).Error("migration rollback failed")
-		}
-	}()
-
 	for _, stmtName := range list {
 		logger := logrus.
 			WithField("method", "migrate").
@@ -93,18 +55,66 @@ func migrate(ctx context.Context, db *sql.DB, list []string, assets http.FileSys
 			continue
 		}
 
-		res, err := tx.ExecContext(ctx, stmt)
+		err = runStatement(ctx, db, stmt)
 		if err != nil {
-			logger.WithError(err).Error("migration failed")
-			return errors.Wrap(err, "migration failed")
+			return err
 		}
-		affected, err := res.RowsAffected()
-		if err != nil {
-			logger.WithError(err).Error("can't count affected rows")
-			return errors.Wrap(err, "can't count affected rows")
-		}
-		logger.WithField("affected", affected).Info("migration finished")
 	}
 
 	return err
+}
+
+func runStatement(ctx context.Context, db *sql.DB, stmt string) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		logrus.Errorf("failed to start migration transaction: %v", err)
+		return err
+	}
+
+	logger := logrus.WithField("method", "runStatement")
+
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			// dirty ugly no-good hack!
+			// we have not seen this in the wild yet, _but_ during our unit tests
+			// we sometimes get this error, which indicates that the transaction  was
+			// started (ie `BEGIN;`) but nothing has happened yet. For example:
+			//    https://www.postgresql.org/message-id/20080617133250.GA68434@commandprompt.com
+			//    https://github.com/lib/pq/issues/225
+			// Initial experiments have only produced this during unit tests, but actual
+			// application environments run without any transaction issues.
+			if err != nil && err.Error() == "pq: unexpected transaction status idle" {
+				logger.WithError(err).Warn("idle transaction at Commit")
+				err = nil
+			}
+			if err != nil {
+				logger.WithError(err).Error("can not commit migrations transaction")
+			}
+			return
+		}
+
+		logger.WithError(err).Error("migration transaction requires rollback")
+
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			err = errors.Wrap(err, rollbackErr.Error())
+			logger.WithError(err).Error("migration rollback failed")
+		}
+	}()
+
+	res, err := tx.ExecContext(ctx, stmt)
+	if err != nil {
+		logger.WithError(err).Error("migration failed")
+		return errors.Wrap(err, "migration failed")
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		logger.WithError(err).Error("can't count affected rows")
+		return errors.Wrap(err, "can't count affected rows")
+	}
+	logger.WithField("affected", affected).Info("migration finished")
+
+	return nil
 }

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -38,7 +38,7 @@ func migrate(ctx context.Context, db *sql.DB, list []string, assets http.FileSys
 			//    https://github.com/lib/pq/issues/225
 			// Initial experiments have only produced this during unit tests, but actual
 			// application environments run without any transaction issues.
-			if err != nil && err.Error() == "pq: unexpected transaction status idle" {
+			if err != nil && err.Error() == idleTransactionErr {
 				logger.WithError(err).Warn("idle transaction at Commit")
 				err = nil
 			}

--- a/pkg/db/migrations/prepare.go
+++ b/pkg/db/migrations/prepare.go
@@ -12,6 +12,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Lock to ensure multiple migrations cannot occur simultaneously
+const lockNum = int64(47831730) // arbitrary random number
+
 // MigrationConfig contains the ordered migration and view sql statements
 // that will be run during startup as well as the assets filesystem object.
 // Use NewSQLAssets to generate this filesystem object.
@@ -54,6 +57,23 @@ func NewPrepareDatabase(config MigrationConfig, queueConfig *QueueDBConfig, appV
 		time.Sleep(GetJitter(config.JitterInterval))
 		logger := logrus.WithField("version", appVersion)
 
+		defer func() {
+			if err != nil {
+				logger.Warnf("migration finished with: %s", err)
+			}
+		}()
+
+		err = acquireAdvisoryLock(ctx, database)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			unlockErr := releaseAdvisoryLock(ctx, database)
+			if err == nil && unlockErr != nil {
+				err = unlockErr
+			}
+		}()
+
 		logger.Debug("preparing migration tracking")
 		// initialize the migration list if does not exist.
 		_, err = database.ExecContext(ctx,
@@ -81,25 +101,7 @@ func NewPrepareDatabase(config MigrationConfig, queueConfig *QueueDBConfig, appV
 			return err
 		}
 
-		defer func() {
-			if err != nil {
-				_ = tx.Rollback()
-				return
-			}
-			err = tx.Commit()
-			if err != nil {
-				logger.Infof("migration finished with: %s", err)
-			}
-		}()
-
-		// SHARE ROW EXCLUSIVE allows other sessions to read the table but nothing else
-		logger.Info("waiting for migration lock")
-		_, err = tx.ExecContext(ctx, `LOCK TABLE migrations IN SHARE ROW EXCLUSIVE MODE;`)
-		if err != nil {
-			return fmt.Errorf("migrations table locked: %s", err)
-		}
-
-		row := tx.QueryRowContext(ctx,
+		row := database.QueryRowContext(ctx,
 			`SELECT version FROM migrations WHERE version = $1;`, appVersion,
 		)
 
@@ -158,7 +160,7 @@ func NewPrepareDatabase(config MigrationConfig, queueConfig *QueueDBConfig, appV
 		}
 
 		// store the migration into the log
-		_, err = tx.ExecContext(ctx, `
+		_, err = database.ExecContext(ctx, `
 			INSERT INTO migrations (version) VALUES ($1);`,
 			appVersion,
 		)
@@ -233,4 +235,14 @@ func GetJitter(interval time.Duration) time.Duration {
 	)
 
 	return time.Duration(minJitter + (random * (maxJitter - minJitter)))
+}
+
+func acquireAdvisoryLock(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, "select pg_advisory_lock($1)", lockNum)
+	return err
+}
+
+func releaseAdvisoryLock(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, "select pg_advisory_unlock($1)", lockNum)
+	return err
 }

--- a/pkg/db/migrations/views.go
+++ b/pkg/db/migrations/views.go
@@ -24,6 +24,23 @@ func NewPostIniter(stmts []string, assets http.FileSystem) func(context.Context,
 }
 
 func configureViews(ctx context.Context, db *sql.DB, stmts []string, assets http.FileSystem) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			err = errors.Wrap(err, rollbackErr.Error())
+		}
+	}()
+
 	for i, stmtName := range stmts {
 		logger := logrus.WithField("stmt", stmtName)
 		logger.Debug("migration started")
@@ -33,11 +50,12 @@ func configureViews(ctx context.Context, db *sql.DB, stmts []string, assets http
 			logger.Errorf("migration failed: %v", err)
 			return fmt.Errorf("migration failed: %w", err)
 		}
-		err = runStatement(ctx, db, stmt)
+
+		_, err = tx.ExecContext(ctx, stmt)
 		if err != nil {
 			return errors.Wrapf(err, "configure view failed at index %d", i)
 		}
 	}
 
-	return nil
+	return err
 }


### PR DESCRIPTION
Using pg_advisory_lock allows us to block multiple application instances
from running migrations at the same time. The current implementation
uses a table lock, but this requires using transactions, which we have
seen behave oddly. This approach allows us to avoid one large global
transaction and we can move the transaction to wrap each individual
statement instead of the entire process.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>