### PR TITLE
ci: update ci workflows to reference main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Test and Publish
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - synchronize
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release Version. Must be an existing tag'
+        description: "Release Version. Must be an existing tag"
         required: true
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     env:
-      default_branch: 'refs/heads/master'
+      default_branch: "refs/heads/main"
 
     # Service containers to run with `container-job`
     services:
@@ -34,8 +34,8 @@ jobs:
           POSTGRES_USER: contiamo_test
           POSTGRES_DB: postgres
         ports:
-        # will assign a random free host port
-        - 5432:5432
+          # will assign a random free host port
+          - 5432:5432
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v2.4.0
       - uses: actions/setup-go@v2.1.5
         with:
-          go-version: '1.16'
+          go-version: "1.16"
       - name: Print env
         run: make env
       - name: Format
@@ -79,7 +79,7 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     env:
-      default_branch: 'refs/heads/master'
+      default_branch: "refs/heads/main"
     steps:
       #####################
       # Release and Publish
@@ -94,3 +94,11 @@ jobs:
           token: ${{ secrets.CONTIAMO_CI_TOKEN }}
           release-type: go-yoshi
           package-name: ""
+          changelog-types: |
+            [
+              {"type":"feat","section":"Features","hidden":false},
+              {"type":"fix","section":"Bug Fixes","hidden":false},
+              {"type":"chore","section":"Miscellaneous","hidden":false},
+              {"type":"docs","section":"Miscellaneous","hidden":false},
+              {"type":"refactor","section":"Miscellaneous","hidden":false}
+            ]

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,6 +1,4 @@
-
-
-name: 'Conventional commit titles'
+name: "Conventional commit titles"
 on:
   pull_request:
     types:
@@ -20,5 +18,5 @@ jobs:
       - uses: deepakputhraya/action-pr-title@master
         with:
           # Ensure pull request titles match the Conventional Commits specification https://www.conventionalcommits.org/en/v1.0.0/
-          # The optional scope is for a Jira ticket number (`CON-xxxx`)
-          regex: '^(feat|fix|chore|ci|refactor|test)(\(CON-\d+\))?!?:'
+          # The scope is optional, but recommended.
+          regex: '^(feat|fix|chore|ci|refactor|test|docs)(\(.+\))?!?:'

--- a/pkg/http/middlewares/metrics_test.go
+++ b/pkg/http/middlewares/metrics_test.go
@@ -62,6 +62,7 @@ func Test_MetricsMiddleware(t *testing.T) {
 		err = testWebsocketEcho(ts.URL)
 		require.NoError(t, err)
 
+		time.Sleep(100 * time.Millisecond)
 		req, err := http.NewRequest(http.MethodGet, ts.URL+"/metrics", nil)
 		require.NoError(t, err)
 		req = req.WithContext(ctx)


### PR DESCRIPTION
Change the default branch name from master to main

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>