### PR TITLE
feat: allow skipping http loggin per request

### DIFF
--- a/pkg/http/middlewares/logging_test.go
+++ b/pkg/http/middlewares/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,7 +36,11 @@ func Test_LoggingMiddleware(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		require.Contains(t, buf.String(), "successfully handled request")
+		data := buf.String()
+		require.Equal(t, 1, strings.Count(data, "\n"))
+		require.Contains(t, data, `level=info`)
+		require.Contains(t, data, `msg="successfully handled request"`)
+		require.Contains(t, data, `app=test duration_millis=0 method=GET path=/logging status_code=200`)
 	})
 
 	t.Run("should support websockets", func(t *testing.T) {
@@ -52,6 +57,61 @@ func Test_LoggingMiddleware(t *testing.T) {
 		require.NoError(t, err)
 
 		time.Sleep(100 * time.Millisecond)
-		require.Contains(t, buf.String(), "successfully handled request")
+		data := buf.String()
+		require.Equal(t, 1, strings.Count(data, "\n"))
+		require.Contains(t, data, `level=info`)
+		require.Contains(t, data, `msg="successfully handled request"`)
+		require.Contains(t, data, `app=test duration_millis=0 method=GET path=/ws/echo status_code=200`)
+	})
+
+	t.Run("should ignore healthchecks", func(t *testing.T) {
+		buf, restore := utils.SetupLoggingBuffer()
+		defer restore()
+
+		srv, err := createServer([]server.Option{WithLogging("test")})
+		require.NoError(t, err)
+
+		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/logging", nil)
+		require.NoError(t, err)
+		req = req.WithContext(ctx)
+		req.Header.Set("User-Agent", "ELB-HealthChecker")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.Equal(t, buf.String(), "")
+	})
+
+	t.Run("should log on error codes", func(t *testing.T) {
+		buf, restore := utils.SetupLoggingBuffer()
+		defer restore()
+
+		srv, err := createServer([]server.Option{WithLogging("test")})
+		require.NoError(t, err)
+
+		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/error", nil)
+		require.NoError(t, err)
+		req = req.WithContext(ctx)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, 400, resp.StatusCode)
+
+		data := buf.String()
+		require.Equal(t, 1, strings.Count(data, "\n"), data)
+		require.Contains(t, data, `level=warn`)
+		require.Contains(t, data, `msg="problem while handling request"`)
+		require.Contains(t, data, `app=test duration_millis=0 method=GET path=/error status_code=400`)
 	})
 }

--- a/pkg/http/middlewares/middleware_test.go
+++ b/pkg/http/middlewares/middleware_test.go
@@ -37,6 +37,10 @@ func createServer(opts []server.Option) (*http.Server, error) {
 
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/ws/", echoWS)
+	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.Copy(w, r.Body)
+	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/panic" {
 			panic("PANIC!!!")

--- a/pkg/http/middlewares/tracing.go
+++ b/pkg/http/middlewares/tracing.go
@@ -31,7 +31,7 @@ type tracingOption struct {
 }
 
 func (opt *tracingOption) WrapHandler(handler http.Handler) http.Handler {
-	mw := middleware(
+	mw := traceMiddleware(
 		opentracing.GlobalTracer(),
 		handler,
 		operationNameFunc(opt.opNameFunc),
@@ -90,7 +90,7 @@ func mwComponentName(componentName string) mwOption {
 // Example:
 //	 http.ListenAndServe("localhost:80", nethttp.Middleware(tracer, http.DefaultServeMux))
 //
-// The options allow fine tuning the behavior of the middleware.
+// The options allow fine tuning the behavior of the traceMiddleware.
 //
 // Example:
 //   mw := nethttp.Middleware(
@@ -103,7 +103,7 @@ func mwComponentName(componentName string) mwOption {
 //			sp.SetTag("http.uri", r.URL.EscapedPath())
 //		}),
 //   )
-func middleware(tr opentracing.Tracer, h http.Handler, options ...mwOption) http.Handler {
+func traceMiddleware(tr opentracing.Tracer, h http.Handler, options ...mwOption) http.Handler {
 	opts := mwOptions{
 		opNameFunc: func(r *http.Request) string {
 			return "HTTP " + r.Method


### PR DESCRIPTION
Provide configuration points to allow application to skip logging on specific requests. Additionally, allow configuration of the log fields as well.

The change should be backwards compatible, because we previously returned an interface, instead of the concrete type. The type still implements the required interface.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>